### PR TITLE
FA icons + webpack error fix

### DIFF
--- a/demos/demo1/index.html
+++ b/demos/demo1/index.html
@@ -4,6 +4,9 @@
 		<title>STORM React Diagrams Test 2</title>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
 		<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 		<script src="https://unpkg.com/react@15.3.1/dist/react.min.js"></script>
 		<script src="https://unpkg.com/react-dom@15.3.1/dist/react-dom.min.js"></script>

--- a/demos/demo2/index.html
+++ b/demos/demo2/index.html
@@ -4,6 +4,9 @@
 		<title>STORM React Diagrams Test 1</title>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
 		<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 		<script src="https://unpkg.com/react@15.3.1/dist/react.min.js"></script>
 		<script src="https://unpkg.com/react-dom@15.3.1/dist/react-dom.min.js"></script>

--- a/demos/demo3/index.html
+++ b/demos/demo3/index.html
@@ -4,6 +4,9 @@
 		<title>STORM React Diagrams Test 1</title>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
 		<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 		<script src="https://unpkg.com/react@15.3.1/dist/react.min.js"></script>
 		<script src="https://unpkg.com/react-dom@15.3.1/dist/react-dom.min.js"></script>

--- a/demos/demo4/index.html
+++ b/demos/demo4/index.html
@@ -4,6 +4,9 @@
 		<title>STORM React Diagrams Test 2</title>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
 		<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 		<script src="https://unpkg.com/react@15.3.1/dist/react.min.js"></script>
 		<script src="https://unpkg.com/react-dom@15.3.1/dist/react-dom.min.js"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 		entry: './src/main.ts',
 		output: {
 			filename: 'main.js',
-			path: './dist',
+			path: __dirname + '/dist',
 			libraryTarget: 'umd',
 			library: 'storm-react-diagrams'
 		},
@@ -61,7 +61,7 @@ module.exports = [
 		},
 		output: {
 			filename: '[name]',
-			path: './demos',
+			path: __dirname + '/demos',
 			libraryTarget: 'umd',
 			library: 'storm-react-diagrams'
 		},


### PR DESCRIPTION
- Webpack was shouting at me:
```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration[0].output.path: The provided value "./dist" is not an absolute path!
```
until I've fixed build paths.

- `fa-close` icons were not shown at all in demos. **Showing them though reveals another issue:** 
![Alt text](https://monosnap.com/file/Ji2n2dz80qJZxJywEMlh19hCCa9P0E.png)

I couldn't track the issue by myself, but initially I thought the issue was the misspelled `iTTerateListeners`. But it's written like that way everywhere. You might want to fix that besides the exception 😄 