### PR TITLE
Adjust defaultNodeModel to allow extras to be inherited when creating…

### DIFF
--- a/src/defaults/DefaultNodeModel.ts
+++ b/src/defaults/DefaultNodeModel.ts
@@ -5,11 +5,11 @@ import * as _ from "lodash";
 import {AbstractInstanceFactory} from "../AbstractInstanceFactory";
 
 export class DefaultNodeInstanceFactory extends AbstractInstanceFactory<DefaultNodeModel>{
-	
+
 	constructor(){
 		super("DefaultNodeModel");
 	}
-	
+
 	getInstance(){
 		return new DefaultNodeModel();
 	}
@@ -19,36 +19,40 @@ export class DefaultNodeInstanceFactory extends AbstractInstanceFactory<DefaultN
  * @author Dylan Vorster
  */
 export class DefaultNodeModel extends NodeModel{
-	
+
 	name: string;
 	color: string;
+	extras: {};
 	ports:  {[s: string]:DefaultPortModel};
-	
-	constructor(name: string = 'Untitled',color: string = 'rgb(0,192,255)'){
+
+	constructor(name: string = 'Untitled',color: string = 'rgb(0,192,255)', extras?:{}){
 		super("default");
 		this.name = name;
 		this.color = color;
+		this.extras = extras;
 	}
-	
+
 	deSerialize(object){
 		super.deSerialize(object);
 		this.name = object.name;
 		this.color = object.color;
+		this.extras = object.extra;
 	}
-	
+
 	serialize(){
 		return _.merge(super.serialize(),{
 			name: this.name,
 			color: this.color,
+			extras: this.extras,
 		});
 	}
-	
+
 	getInPorts(): DefaultPortModel[]{
 		return _.filter(this.ports,(portModel) => {
 			return portModel.in;
 		});
 	}
-	
+
 	getOutPorts(): DefaultPortModel[]{
 		return _.filter(this.ports,(portModel) => {
 			return !portModel.in;


### PR DESCRIPTION
Adjust defaultNodeModel to allow extras to be inherited. The following should pass the extras into the function upon creation. Can you please help me double check to see if any syntax issue or implementation since I have not worked much with ts. Thank you.

@dylanvorster 

Upstream:
Adding additional properties to default nodes [#43](https://github.com/projectstorm/react-diagrams/issues/43)