### PR TITLE
`LinkModel` should import the `extras` field

### DIFF
--- a/src/Common.ts
+++ b/src/Common.ts
@@ -141,6 +141,7 @@ export class LinkModel extends BaseModel<LinkModelListener>{
 	deSerialize(ob){
 		super.deSerialize(ob);
 		this.linkType = ob.type;
+		this.extras = ob.extras;
 		this.points = _.map(ob.points,(point: {x,y}) => {
 			var p = new PointModel(this, {x: point.x,y:point.y});
 			p.deSerialize(point);

--- a/src/defaults/DefaultPortLabelWidget.ts
+++ b/src/defaults/DefaultPortLabelWidget.ts
@@ -4,6 +4,8 @@ import {PortWidget} from "../widgets/PortWidget";
 
 export interface DefaultPortLabelProps {
 	model?: DefaultPortModel;
+	in?: boolean;
+	label?: string;
 }
 
 export interface DefaultPortLabelState {


### PR DESCRIPTION
The `LinkModel`, hardcoded in the *react-diagrams*, actually has an `extras` field of type Object. But inserting information there, serializing and then deserializing, doesn't get the data back again.