### PR TITLE
fix #73: is locked check in default link widget (for complex line)

### DIFF
--- a/demos/demo4/index.tsx
+++ b/demos/demo4/index.tsx
@@ -5,6 +5,7 @@ import {
 	DiagramModel,
 	DefaultNodeModel,
 	LinkModel,
+	PointModel,
 	DiagramWidget
 } from "../../src/main";
 
@@ -23,6 +24,7 @@ export default () => {
 
 	var model = new DiagramModel();
 
+	// sample for link with simple line (no additional points)
 	var node1 = new DefaultNodeModel("Node 1","rgb(0,192,255)");
 	var port1 = node1.addPort(new SRD.DefaultPortModel(false,"out-1","Out"));
 	node1.x = 100;
@@ -40,6 +42,30 @@ export default () => {
 	model.addNode(node1);
 	model.addNode(node2);
 	model.addLink(link1);
+
+	// sample for link with complex line (additional points)
+	var node3 = new DefaultNodeModel("Node 3","rgb(0,192,255)");
+	var port3 = node3.addPort(new SRD.DefaultPortModel(false,"out-2","Out"));
+	node3.x = 100;
+	node3.y = 250;
+
+	var node4 = new DefaultNodeModel("Node 4","rgb(192,255,0)");
+	var port4 = node4.addPort(new SRD.DefaultPortModel(true,"in-2","IN"));
+	node4.x = 400;
+	node4.y = 250;
+
+	var link2 = new LinkModel();
+	link2.setSourcePort(port3);
+	link2.setTargetPort(port4);
+
+	var additionalPoint1 = new PointModel(link2,{x:350,y:225});
+	link2.addPoint(additionalPoint1);
+	var additionalPoint2 = new PointModel(link2,{x:200,y:225});
+	link2.addPoint(additionalPoint2);
+
+	model.addNode(node3);
+	model.addNode(node4);
+	model.addLink(link2);
 
 	engine.setDiagramModel(model);
 

--- a/src/defaults/DefaultLinkWidget.tsx
+++ b/src/defaults/DefaultLinkWidget.tsx
@@ -174,7 +174,7 @@ export class DefaultLinkWidget extends React.Component<DefaultLinkProps, Default
 					'data-linkid':this.props.link.id,
 					'data-point':index,
 					onMouseDown: (event: MouseEvent) => {
-						if (!event.shiftKey){
+						if (!event.shiftKey && !this.props.diagramEngine.isModelLocked(this.props.link)){
 							var point = new PointModel(this.props.link,this.props.diagramEngine.getRelativeMousePoint(event));
 							point.setSelected(true);
 							this.forceUpdate();


### PR DESCRIPTION
extend fix for issue #73.
adapt is locked check in default link widget for complex line (with additional points) as it was made for simple line.
add example for link with complex line in storybook.