### PR TITLE
Add Prettier and lint project

### DIFF
--- a/demos/demo1/index.tsx
+++ b/demos/demo1/index.tsx
@@ -11,7 +11,6 @@ import {
 import * as React from "react";
 
 export default () => {
-
 	//1) setup the diagram engine
 	var engine = new DiagramEngine();
 	engine.registerNodeFactory(new DefaultNodeFactory());
@@ -21,14 +20,14 @@ export default () => {
 	var model = new DiagramModel();
 
 	//3-A) create a default node
-	var node1 = new DefaultNodeModel("Node 1","rgb(0,192,255)");
-	var port1 = node1.addPort(new DefaultPortModel(false,"out-1","Out"));
+	var node1 = new DefaultNodeModel("Node 1", "rgb(0,192,255)");
+	var port1 = node1.addPort(new DefaultPortModel(false, "out-1", "Out"));
 	node1.x = 100;
 	node1.y = 100;
 
 	//3-B) create another default node
-	var node2 = new DefaultNodeModel("Node 2","rgb(192,255,0)");
-	var port2 = node2.addPort(new DefaultPortModel(true,"in-1","IN"));
+	var node2 = new DefaultNodeModel("Node 2", "rgb(192,255,0)");
+	var port2 = node2.addPort(new DefaultPortModel(true, "in-1", "IN"));
 	node2.x = 400;
 	node2.y = 100;
 
@@ -47,5 +46,4 @@ export default () => {
 
 	//6) render the diagram!
 	return <DiagramWidget diagramEngine={engine} />;
-
 };

--- a/demos/demo2/index.tsx
+++ b/demos/demo2/index.tsx
@@ -18,22 +18,25 @@ import * as React from "react";
  * @Author Dylan Vorster
  */
 export default () => {
-
 	//1) setup the diagram engine
 	var engine = new DiagramEngine();
 	engine.registerNodeFactory(new DefaultNodeFactory());
 	engine.registerLinkFactory(new DefaultLinkFactory());
 
-	function generateNodes(model: DiagramModel, offsetX: number,offsetY: number){
+	function generateNodes(
+		model: DiagramModel,
+		offsetX: number,
+		offsetY: number
+	) {
 		//3-A) create a default node
-		var node1 = new DefaultNodeModel("Node 1","rgb(0,192,255)");
-		var port1 = node1.addPort(new DefaultPortModel(false,"out-1","Out"));
+		var node1 = new DefaultNodeModel("Node 1", "rgb(0,192,255)");
+		var port1 = node1.addPort(new DefaultPortModel(false, "out-1", "Out"));
 		node1.x = 100 + offsetX;
 		node1.y = 100 + offsetY;
 
 		//3-B) create another default node
-		var node2 = new DefaultNodeModel("Node 2","rgb(192,255,0)");
-		var port2 = node2.addPort(new DefaultPortModel(true,"in-1","IN"));
+		var node2 = new DefaultNodeModel("Node 2", "rgb(192,255,0)");
+		var port2 = node2.addPort(new DefaultPortModel(true, "in-1", "IN"));
 		node2.x = 200 + offsetX;
 		node2.y = 100 + offsetY;
 
@@ -51,9 +54,9 @@ export default () => {
 	//2) setup the diagram model
 	var model = new DiagramModel();
 
-	for(var i =0;i < 8;i++){
-		for(var j = 0;j < 8;j++){
-			generateNodes(model,i*200,j*100);
+	for (var i = 0; i < 8; i++) {
+		for (var j = 0; j < 8; j++) {
+			generateNodes(model, i * 200, j * 100);
 		}
 	}
 
@@ -62,5 +65,4 @@ export default () => {
 
 	//6) render the diagram!
 	return <DiagramWidget diagramEngine={engine} />;
-
-}
+};

--- a/demos/demo3/DiamondInstanceFactories.ts
+++ b/demos/demo3/DiamondInstanceFactories.ts
@@ -1,25 +1,27 @@
 import * as SRD from "../../src/main";
-import {DiamondNodeModel} from "./DiamondNodeModel";
-import {DiamondPortModel} from "./DiamondPortModel";
+import { DiamondNodeModel } from "./DiamondNodeModel";
+import { DiamondPortModel } from "./DiamondPortModel";
 
-export class DiamondNodeFactory extends SRD.AbstractInstanceFactory<DiamondNodeModel>{
-	
-	constructor(){
+export class DiamondNodeFactory extends SRD.AbstractInstanceFactory<
+	DiamondNodeModel
+> {
+	constructor() {
 		super("DiamondNodeModel");
 	}
-	
-	getInstance(){
+
+	getInstance() {
 		return new DiamondNodeModel();
 	}
 }
 
-export class DiamondPortFactory extends SRD.AbstractInstanceFactory<DiamondPortModel>{
-	
-	constructor(){
+export class DiamondPortFactory extends SRD.AbstractInstanceFactory<
+	DiamondPortModel
+> {
+	constructor() {
 		super("DiamondPortModel");
 	}
-	
-	getInstance(){
+
+	getInstance() {
 		return new DiamondPortModel();
 	}
 }

--- a/demos/demo3/DiamondNodeModel.ts
+++ b/demos/demo3/DiamondNodeModel.ts
@@ -1,14 +1,12 @@
 import * as SRD from "../../src/main";
-import {DiamondPortModel} from "./DiamondPortModel";
+import { DiamondPortModel } from "./DiamondPortModel";
 
-export class DiamondNodeModel extends SRD.NodeModel{
-	
-	constructor(){
-		super('diamond');
-		this.addPort(new DiamondPortModel('top'));
-		this.addPort(new DiamondPortModel('left'));
-		this.addPort(new DiamondPortModel('bottom'));
-		this.addPort(new DiamondPortModel('right'));
+export class DiamondNodeModel extends SRD.NodeModel {
+	constructor() {
+		super("diamond");
+		this.addPort(new DiamondPortModel("top"));
+		this.addPort(new DiamondPortModel("left"));
+		this.addPort(new DiamondPortModel("bottom"));
+		this.addPort(new DiamondPortModel("right"));
 	}
-	
 }

--- a/demos/demo3/DiamondNodeWidget.tsx
+++ b/demos/demo3/DiamondNodeWidget.tsx
@@ -1,20 +1,21 @@
 import * as React from "react";
-import {DiamondNodeModel} from "./DiamondNodeModel";
-import {PortWidget} from "../../src/main";
+import { DiamondNodeModel } from "./DiamondNodeModel";
+import { PortWidget } from "../../src/main";
 
 export interface DiamonNodeWidgetProps {
-	node: DiamondNodeModel,
-	size?: number
+	node: DiamondNodeModel;
+	size?: number;
 }
 
-export interface DiamonNodeWidgetState {
-}
+export interface DiamonNodeWidgetState {}
 
 /**
  * @author Dylan Vorster
  */
-export class DiamonNodeWidget extends React.Component<DiamonNodeWidgetProps, DiamonNodeWidgetState> {
-
+export class DiamonNodeWidget extends React.Component<
+	DiamonNodeWidgetProps,
+	DiamonNodeWidgetState
+> {
 	public static defaultProps: DiamonNodeWidgetProps = {
 		size: 150,
 		node: null
@@ -22,34 +23,87 @@ export class DiamonNodeWidget extends React.Component<DiamonNodeWidgetProps, Dia
 
 	constructor(props: DiamonNodeWidgetProps) {
 		super(props);
-		this.state = {
-		}
+		this.state = {};
 	}
 
 	render() {
 		return (
-			<div className={"diamond-node"} style={{position: 'relative', width: this.props.size, height: this.props.size}}>
-				<svg width={this.props.size} height={this.props.size} dangerouslySetInnerHTML={{__html:`
+			<div
+				className={"diamond-node"}
+				style={{
+					position: "relative",
+					width: this.props.size,
+					height: this.props.size
+				}}
+			>
+				<svg
+					width={this.props.size}
+					height={this.props.size}
+					dangerouslySetInnerHTML={{
+						__html:
+							`
 					<g id="Layer_1">
 					</g>
 					<g id="Layer_2">
-						<polygon fill="purple" stroke="#000000" stroke-width="3" stroke-miterlimit="10" points="10,`+(this.props.size/2)+` `+(this.props.size/2)+`,10 `+(this.props.size-10)+`,`+(this.props.size/2)+` `+(this.props.size/2)+`,`+(this.props.size-10)+` "/>
+						<polygon fill="purple" stroke="#000000" stroke-width="3" stroke-miterlimit="10" points="10,` +
+							this.props.size / 2 +
+							` ` +
+							this.props.size / 2 +
+							`,10 ` +
+							(this.props.size - 10) +
+							`,` +
+							this.props.size / 2 +
+							` ` +
+							this.props.size / 2 +
+							`,` +
+							(this.props.size - 10) +
+							` "/>
 					</g>
-				`}} />
-				<div style={{position:'absolute', zIndex:10, top:this.props.size/2 - 8, left: -8 }}>
-					<PortWidget name='left' node={this.props.node} />
+				`
+					}}
+				/>
+				<div
+					style={{
+						position: "absolute",
+						zIndex: 10,
+						top: this.props.size / 2 - 8,
+						left: -8
+					}}
+				>
+					<PortWidget name="left" node={this.props.node} />
 				</div>
-				<div style={{position:'absolute', zIndex:10, left:this.props.size/2-8, top:-8 }}>
-					<PortWidget name='top' node={this.props.node} />
+				<div
+					style={{
+						position: "absolute",
+						zIndex: 10,
+						left: this.props.size / 2 - 8,
+						top: -8
+					}}
+				>
+					<PortWidget name="top" node={this.props.node} />
 				</div>
-				<div style={{position: 'absolute', zIndex:10,left:this.props.size-8,top:this.props.size/2 - 8 }}>
-					<PortWidget name='right' node={this.props.node} />
+				<div
+					style={{
+						position: "absolute",
+						zIndex: 10,
+						left: this.props.size - 8,
+						top: this.props.size / 2 - 8
+					}}
+				>
+					<PortWidget name="right" node={this.props.node} />
 				</div>
-				<div style={{position: 'absolute', zIndex:10,left :this.props.size/2 - 8,top:this.props.size-8}}>
-					<PortWidget name='bottom' node={this.props.node} />
+				<div
+					style={{
+						position: "absolute",
+						zIndex: 10,
+						left: this.props.size / 2 - 8,
+						top: this.props.size - 8
+					}}
+				>
+					<PortWidget name="bottom" node={this.props.node} />
 				</div>
 			</div>
-		)
+		);
 	}
 }
 

--- a/demos/demo3/DiamondPortModel.ts
+++ b/demos/demo3/DiamondPortModel.ts
@@ -1,24 +1,22 @@
 import * as SRD from "../../src/main";
 import * as _ from "lodash";
 
-export class DiamondPortModel extends SRD.PortModel{
-	
-	position: string|'top'|'bottom'|'left'|'right';
-	
-	constructor(pos: string = 'top'){
+export class DiamondPortModel extends SRD.PortModel {
+	position: string | "top" | "bottom" | "left" | "right";
+
+	constructor(pos: string = "top") {
 		super(pos);
-		this.position = pos ;
+		this.position = pos;
 	}
-	
-	serialize(){
-		return _.merge(super.serialize(),{
-			position: this.position,
+
+	serialize() {
+		return _.merge(super.serialize(), {
+			position: this.position
 		});
 	}
-	
-	deSerialize(data:any){
+
+	deSerialize(data: any) {
 		super.deSerialize(data);
 		this.position = data.position;
 	}
-	
 }

--- a/demos/demo3/DiamondWidgetFactory.ts
+++ b/demos/demo3/DiamondWidgetFactory.ts
@@ -1,13 +1,15 @@
 import * as SRD from "../../src/main";
-import {DiamonNodeWidgetFactory} from "./DiamondNodeWidget";
+import { DiamonNodeWidgetFactory } from "./DiamondNodeWidget";
 
-export class DiamondWidgetFactory extends SRD.NodeWidgetFactory{
-	
-	constructor(){
-		super('diamond');
+export class DiamondWidgetFactory extends SRD.NodeWidgetFactory {
+	constructor() {
+		super("diamond");
 	}
-	
-	generateReactWidget(diagramEngine:SRD.DiagramEngine,node: SRD.NodeModel): JSX.Element{
-		return DiamonNodeWidgetFactory({node: node});
+
+	generateReactWidget(
+		diagramEngine: SRD.DiagramEngine,
+		node: SRD.NodeModel
+	): JSX.Element {
+		return DiamonNodeWidgetFactory({ node: node });
 	}
 }

--- a/demos/demo3/index.tsx
+++ b/demos/demo3/index.tsx
@@ -9,28 +9,25 @@ import {
 	DiagramWidget
 } from "../../src/main";
 import * as React from "react";
-import {DiamondNodeModel} from "./DiamondNodeModel";
-import {DiamondWidgetFactory} from "./DiamondWidgetFactory";
-
+import { DiamondNodeModel } from "./DiamondNodeModel";
+import { DiamondWidgetFactory } from "./DiamondWidgetFactory";
 
 /**
  * @Author Dylan Vorster
  */
 export default () => {
-
 	//1) setup the diagram engine
 	var engine = new DiagramEngine();
 	engine.registerNodeFactory(new DefaultNodeFactory());
 	engine.registerLinkFactory(new DefaultLinkFactory());
 	engine.registerNodeFactory(new DiamondWidgetFactory());
 
-
 	//2) setup the diagram model
 	var model = new DiagramModel();
 
 	//3-A) create a default node
-	var node1 = new DefaultNodeModel("Node 1","rgb(0,192,255)");
-	var port1 = node1.addPort(new DefaultPortModel(false,"out-1","Out"));
+	var node1 = new DefaultNodeModel("Node 1", "rgb(0,192,255)");
+	var port1 = node1.addPort(new DefaultPortModel(false, "out-1", "Out"));
 	node1.x = 100;
 	node1.y = 150;
 
@@ -39,18 +36,18 @@ export default () => {
 	node2.x = 400;
 	node2.y = 100;
 
-	var node3 = new DefaultNodeModel("Node 3","red");
-	var port3 = node3.addPort(new DefaultPortModel(true,"in-1","In"));
+	var node3 = new DefaultNodeModel("Node 3", "red");
+	var port3 = node3.addPort(new DefaultPortModel(true, "in-1", "In"));
 	node3.x = 800;
 	node3.y = 150;
 
 	//3-C) link the 2 nodes together
 	var link1 = new LinkModel();
 	link1.setSourcePort(port1);
-	link1.setTargetPort(node2.ports['left']);
+	link1.setTargetPort(node2.ports["left"]);
 
 	var link2 = new LinkModel();
-	link2.setSourcePort(node2.ports['right']);
+	link2.setSourcePort(node2.ports["right"]);
 	link2.setTargetPort(port3);
 
 	//4) add the models to the root graph
@@ -65,28 +62,27 @@ export default () => {
 
 	//6) render the diagram!
 
-	return <DiagramWidget diagramEngine={engine} />
-
+	return <DiagramWidget diagramEngine={engine} />;
 
 	// //!------------- SERIALIZING / DESERIALIZING ------------
-    //
+	//
 	// //we need this to help the system know what models to create form the JSON
 	// engine.registerInstanceFactory(new SRD.DefaultNodeInstanceFactory());
 	// engine.registerInstanceFactory(new SRD.DefaultPortInstanceFactory());
 	// engine.registerInstanceFactory(new SRD.LinkInstanceFactory());
 	// engine.registerInstanceFactory(new DiamondNodeFactory());
 	// engine.registerInstanceFactory(new DiamondPortFactory());
-    //
+	//
 	// //serialize the model
 	// var str = JSON.stringify(model.serializeDiagram());
 	// console.log(str);
-    //
+	//
 	// //deserialize the model
 	// var model2 = new SRD.DiagramModel();
 	// model2.deSerializeDiagram(JSON.parse(str),engine);
 	// engine.setDiagramModel(model2);
 	// console.log(model2);
-    //
+	//
 	// //re-render the model
 	// ReactDOM.render(React.createElement(SRD.DiagramWidget,{diagramEngine: engine}), document.body);
-}
+};

--- a/demos/demo4/index.tsx
+++ b/demos/demo4/index.tsx
@@ -16,7 +16,6 @@ import {
  * @Author Dylan Vorster
  */
 export default () => {
-
 	//1) setup the diagram engine
 	var engine = new DiagramEngine();
 	engine.registerNodeFactory(new SRD.DefaultNodeFactory());
@@ -25,13 +24,13 @@ export default () => {
 	var model = new DiagramModel();
 
 	// sample for link with simple line (no additional points)
-	var node1 = new DefaultNodeModel("Node 1","rgb(0,192,255)");
-	var port1 = node1.addPort(new SRD.DefaultPortModel(false,"out-1","Out"));
+	var node1 = new DefaultNodeModel("Node 1", "rgb(0,192,255)");
+	var port1 = node1.addPort(new SRD.DefaultPortModel(false, "out-1", "Out"));
 	node1.x = 100;
 	node1.y = 100;
 
-	var node2 = new DefaultNodeModel("Node 2","rgb(192,255,0)");
-	var port2 = node2.addPort(new SRD.DefaultPortModel(true,"in-1","IN"));
+	var node2 = new DefaultNodeModel("Node 2", "rgb(192,255,0)");
+	var port2 = node2.addPort(new SRD.DefaultPortModel(true, "in-1", "IN"));
 	node2.x = 400;
 	node2.y = 100;
 
@@ -44,13 +43,13 @@ export default () => {
 	model.addLink(link1);
 
 	// sample for link with complex line (additional points)
-	var node3 = new DefaultNodeModel("Node 3","rgb(0,192,255)");
-	var port3 = node3.addPort(new SRD.DefaultPortModel(false,"out-2","Out"));
+	var node3 = new DefaultNodeModel("Node 3", "rgb(0,192,255)");
+	var port3 = node3.addPort(new SRD.DefaultPortModel(false, "out-2", "Out"));
 	node3.x = 100;
 	node3.y = 250;
 
-	var node4 = new DefaultNodeModel("Node 4","rgb(192,255,0)");
-	var port4 = node4.addPort(new SRD.DefaultPortModel(true,"in-2","IN"));
+	var node4 = new DefaultNodeModel("Node 4", "rgb(192,255,0)");
+	var port4 = node4.addPort(new SRD.DefaultPortModel(true, "in-2", "IN"));
 	node4.x = 400;
 	node4.y = 250;
 
@@ -58,9 +57,9 @@ export default () => {
 	link2.setSourcePort(port3);
 	link2.setTargetPort(port4);
 
-	var additionalPoint1 = new PointModel(link2,{x:350,y:225});
+	var additionalPoint1 = new PointModel(link2, { x: 350, y: 225 });
 	link2.addPoint(additionalPoint1);
-	var additionalPoint2 = new PointModel(link2,{x:200,y:225});
+	var additionalPoint2 = new PointModel(link2, { x: 200, y: 225 });
 	link2.addPoint(additionalPoint2);
 
 	model.addNode(node3);
@@ -82,4 +81,4 @@ export default () => {
 	//!=========================================  <<<<<<<
 
 	return <DiagramWidget {...props} />;
-}
+};

--- a/demos/demo5/Application.ts
+++ b/demos/demo5/Application.ts
@@ -2,32 +2,30 @@ import * as SRD from "../../src/main";
 /**
  * @author Dylan Vorster
  */
-export class Application{
-	
+export class Application {
 	protected activeModel: SRD.DiagramModel;
 	protected diagramEngine: SRD.DiagramEngine;
-	
-	constructor(){
+
+	constructor() {
 		this.diagramEngine = new SRD.DiagramEngine();
-		
+
 		this.diagramEngine.registerNodeFactory(new SRD.DefaultNodeFactory());
 		this.diagramEngine.registerLinkFactory(new SRD.DefaultLinkFactory());
-		
+
 		this.newModel();
 	}
-	
-	public newModel(){
+
+	public newModel() {
 		this.activeModel = new SRD.DiagramModel();
 		this.diagramEngine.setDiagramModel(this.activeModel);
-		
-		
-		var node1 = new SRD.DefaultNodeModel("Node 1","rgb(0,192,255)");
-		var port1 = node1.addPort(new SRD.DefaultPortModel(false,"out-1","Out"));
+
+		var node1 = new SRD.DefaultNodeModel("Node 1", "rgb(0,192,255)");
+		var port1 = node1.addPort(new SRD.DefaultPortModel(false, "out-1", "Out"));
 		node1.x = 100;
 		node1.y = 100;
 
-		var node2 = new SRD.DefaultNodeModel("Node 2","rgb(192,255,0)");
-		var port2 = node2.addPort(new SRD.DefaultPortModel(true,"in-1","IN"));
+		var node2 = new SRD.DefaultNodeModel("Node 2", "rgb(192,255,0)");
+		var port2 = node2.addPort(new SRD.DefaultPortModel(true, "in-1", "IN"));
 		node2.x = 400;
 		node2.y = 100;
 
@@ -39,13 +37,12 @@ export class Application{
 		this.activeModel.addNode(node2);
 		this.activeModel.addLink(link1);
 	}
-	
-	public getActiveDiagram(): SRD.DiagramModel{
+
+	public getActiveDiagram(): SRD.DiagramModel {
 		return this.activeModel;
 	}
-	
-	public getDiagramEngine(): SRD.DiagramEngine{
+
+	public getDiagramEngine(): SRD.DiagramEngine {
 		return this.diagramEngine;
 	}
-	
 }

--- a/demos/demo5/components/BodyWidget.tsx
+++ b/demos/demo5/components/BodyWidget.tsx
@@ -1,27 +1,27 @@
 import * as React from "react";
 import * as _ from "lodash";
-import {TrayWidget} from "./TrayWidget";
-import {DiagramWidget} from "../../../src/main";
-import {Application} from "../Application";
-import {TrayItemWidget} from "./TrayItemWidget";
-import {DefaultNodeModel,DefaultPortModel} from "../../../src/main";
+import { TrayWidget } from "./TrayWidget";
+import { DiagramWidget } from "../../../src/main";
+import { Application } from "../Application";
+import { TrayItemWidget } from "./TrayItemWidget";
+import { DefaultNodeModel, DefaultPortModel } from "../../../src/main";
 
 export interface BodyWidgetProps {
 	app: Application;
 }
 
-export interface BodyWidgetState {
-}
+export interface BodyWidgetState {}
 
 /**
  * @author Dylan Vorster
  */
-export class BodyWidget extends React.Component<BodyWidgetProps, BodyWidgetState> {
-
+export class BodyWidget extends React.Component<
+	BodyWidgetProps,
+	BodyWidgetState
+> {
 	constructor(props: BodyWidgetProps) {
 		super(props);
-		this.state = {
-		}
+		this.state = {};
 	}
 
 	render() {
@@ -32,39 +32,63 @@ export class BodyWidget extends React.Component<BodyWidgetProps, BodyWidgetState
 				</div>
 				<div className="content">
 					<TrayWidget>
-						<TrayItemWidget model={{type: 'in'}} name="In Node" color="rgb(192,255,0)"/>
-						<TrayItemWidget model={{type: 'out'}} name="Out Node" color="rgb(0,192,255)"/>
+						<TrayItemWidget
+							model={{ type: "in" }}
+							name="In Node"
+							color="rgb(192,255,0)"
+						/>
+						<TrayItemWidget
+							model={{ type: "out" }}
+							name="Out Node"
+							color="rgb(0,192,255)"
+						/>
 					</TrayWidget>
 					<div
 						className="diagram-layer"
-						onDrop={(event) => {
-
-							var data = JSON.parse(event.dataTransfer.getData('storm-diagram-node'));
-							var nodesCount = _.keys(this.props.app.getDiagramEngine().getDiagramModel().getNodes()).length;
+						onDrop={event => {
+							var data = JSON.parse(
+								event.dataTransfer.getData("storm-diagram-node")
+							);
+							var nodesCount = _.keys(
+								this.props.app
+									.getDiagramEngine()
+									.getDiagramModel()
+									.getNodes()
+							).length;
 
 							var node = null;
-							if(data.type === 'in'){
-								node = new DefaultNodeModel("Node "+(nodesCount+1),"rgb(192,255,0)");
-								node.addPort(new DefaultPortModel(true,"in-1","In"));
-							}else{
-								node = new DefaultNodeModel("Node "+(nodesCount+1),"rgb(0,192,255)");
-								node.addPort(new DefaultPortModel(false,"out-1","Out"));
+							if (data.type === "in") {
+								node = new DefaultNodeModel(
+									"Node " + (nodesCount + 1),
+									"rgb(192,255,0)"
+								);
+								node.addPort(new DefaultPortModel(true, "in-1", "In"));
+							} else {
+								node = new DefaultNodeModel(
+									"Node " + (nodesCount + 1),
+									"rgb(0,192,255)"
+								);
+								node.addPort(new DefaultPortModel(false, "out-1", "Out"));
 							}
-							var points = this.props.app.getDiagramEngine().getRelativeMousePoint(event);
+							var points = this.props.app
+								.getDiagramEngine()
+								.getRelativeMousePoint(event);
 							node.x = points.x;
 							node.y = points.y;
-							this.props.app.getDiagramEngine().getDiagramModel().addNode(node);
+							this.props.app
+								.getDiagramEngine()
+								.getDiagramModel()
+								.addNode(node);
 							this.forceUpdate();
-
 						}}
-						onDragOver={(event) => {
+						onDragOver={event => {
 							event.preventDefault();
 						}}
 					>
-						<DiagramWidget diagramEngine={this.props.app.getDiagramEngine()}/>
+						<DiagramWidget diagramEngine={this.props.app.getDiagramEngine()} />
 					</div>
 				</div>
 			</div>
-		)
+		);
 	}
 }

--- a/demos/demo5/components/TrayItemWidget.tsx
+++ b/demos/demo5/components/TrayItemWidget.tsx
@@ -6,23 +6,27 @@ export interface TrayItemWidgetProps {
 	name: string;
 }
 
-export interface TrayItemWidgetState {
-}
+export interface TrayItemWidgetState {}
 
-export class TrayItemWidget extends React.Component<TrayItemWidgetProps, TrayItemWidgetState> {
-
+export class TrayItemWidget extends React.Component<
+	TrayItemWidgetProps,
+	TrayItemWidgetState
+> {
 	constructor(props: TrayItemWidgetProps) {
 		super(props);
-		this.state = {}
+		this.state = {};
 	}
 
 	render() {
 		return (
 			<div
-				style={{borderColor: this.props.color}}
+				style={{ borderColor: this.props.color }}
 				draggable={true}
-				onDragStart={(event) => {
-					event.dataTransfer.setData("storm-diagram-node", JSON.stringify(this.props.model));
+				onDragStart={event => {
+					event.dataTransfer.setData(
+						"storm-diagram-node",
+						JSON.stringify(this.props.model)
+					);
 				}}
 				className="tray-item"
 			>

--- a/demos/demo5/components/TrayWidget.tsx
+++ b/demos/demo5/components/TrayWidget.tsx
@@ -1,28 +1,24 @@
 import * as React from "react";
 
-export interface TrayWidgetProps {
-}
+export interface TrayWidgetProps {}
 
-export interface TrayWidgetState {
-}
+export interface TrayWidgetState {}
 
 /**
  * @author Dylan Vorster
  */
-export class TrayWidget extends React.Component<TrayWidgetProps, TrayWidgetState> {
-
-	public static defaultProps: TrayWidgetProps = {
-	};
+export class TrayWidget extends React.Component<
+	TrayWidgetProps,
+	TrayWidgetState
+> {
+	public static defaultProps: TrayWidgetProps = {};
 
 	constructor(props: TrayWidgetProps) {
 		super(props);
-		this.state = {
-		}
+		this.state = {};
 	}
 
 	render() {
-		return (
-			<div className="tray">{this.props.children}</div>
-		)
+		return <div className="tray">{this.props.children}</div>;
 	}
 }

--- a/demos/demo5/index.tsx
+++ b/demos/demo5/index.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 
-import {BodyWidget} from "./components/BodyWidget";
-import {Application} from "./Application";
+import { BodyWidget } from "./components/BodyWidget";
+import { Application } from "./Application";
 
 require("./sass/main.scss");
 
 export default () => {
-
 	var app = new Application();
 
 	return <BodyWidget app={app} />;
-}
+};

--- a/demos/demo6/index.tsx
+++ b/demos/demo6/index.tsx
@@ -14,7 +14,6 @@ import {
 import * as React from "react";
 
 export default () => {
-
 	//1) setup the diagram engine
 	var engine = new DiagramEngine();
 	engine.registerNodeFactory(new DefaultNodeFactory());
@@ -24,14 +23,14 @@ export default () => {
 	var model = new DiagramModel();
 
 	//3-A) create a default node
-	var node1 = new DefaultNodeModel("Node 1","rgb(0,192,255)");
-	var port1 = node1.addPort(new DefaultPortModel(false,"out-1","Out"));
+	var node1 = new DefaultNodeModel("Node 1", "rgb(0,192,255)");
+	var port1 = node1.addPort(new DefaultPortModel(false, "out-1", "Out"));
 	node1.x = 100;
 	node1.y = 100;
 
 	//3-B) create another default node
-	var node2 = new DefaultNodeModel("Node 2","rgb(192,255,0)");
-	var port2 = node2.addPort(new DefaultPortModel(true,"in-1","IN"));
+	var node2 = new DefaultNodeModel("Node 2", "rgb(192,255,0)");
+	var port2 = node2.addPort(new DefaultPortModel(true, "in-1", "IN"));
 	node2.x = 400;
 	node2.y = 100;
 
@@ -48,7 +47,6 @@ export default () => {
 	//5) load model into engine
 	engine.setDiagramModel(model);
 
-
 	//!------------- SERIALIZING ------------------
 
 	var str = JSON.stringify(model.serializeDiagram());
@@ -62,9 +60,8 @@ export default () => {
 
 	//deserialize the model
 	var model2 = new DiagramModel();
-	model2.deSerializeDiagram(JSON.parse(str),engine);
+	model2.deSerializeDiagram(JSON.parse(str), engine);
 	engine.setDiagramModel(model2);
 
 	return <DiagramWidget diagramEngine={engine} />;
-
 };

--- a/demos/demo7/index.tsx
+++ b/demos/demo7/index.tsx
@@ -14,7 +14,6 @@ import * as React from "react";
  * Tests the grid size
  */
 export default () => {
-
 	//1) setup the diagram engine
 	var engine = new DiagramEngine();
 	engine.registerNodeFactory(new DefaultNodeFactory());
@@ -25,14 +24,14 @@ export default () => {
 	model.setGridSize(50);
 
 	//3-A) create a default node
-	var node1 = new DefaultNodeModel("Node 1","rgb(0,192,255)");
-	var port1 = node1.addPort(new DefaultPortModel(false,"out-1","Out"));
+	var node1 = new DefaultNodeModel("Node 1", "rgb(0,192,255)");
+	var port1 = node1.addPort(new DefaultPortModel(false, "out-1", "Out"));
 	node1.x = 100;
 	node1.y = 100;
 
 	//3-B) create another default node
-	var node2 = new DefaultNodeModel("Node 2","rgb(192,255,0)");
-	var port2 = node2.addPort(new DefaultPortModel(true,"in-1","IN"));
+	var node2 = new DefaultNodeModel("Node 2", "rgb(192,255,0)");
+	var port2 = node2.addPort(new DefaultPortModel(true, "in-1", "IN"));
 	node2.x = 400;
 	node2.y = 100;
 
@@ -51,5 +50,4 @@ export default () => {
 
 	//6) render the diagram!
 	return <DiagramWidget diagramEngine={engine} />;
-
 };

--- a/demos/index.tsx
+++ b/demos/index.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 
 import demo1 from "./demo1/index";
 import demo2 from "./demo2/index";
@@ -12,25 +12,25 @@ import demo7 from "./demo7/index";
 
 require("./test.scss");
 
-storiesOf('React Diagrams', module)
-	.add('Simple Example', () => {
+storiesOf("React Diagrams", module)
+	.add("Simple Example", () => {
 		return demo1();
 	})
-	.add('Performance Test', () => {
+	.add("Performance Test", () => {
 		return demo2();
 	})
-	.add('Custom Diamond Widget', () => {
+	.add("Custom Diamond Widget", () => {
 		return demo3();
 	})
-	.add('Locked Widget', () => {
+	.add("Locked Widget", () => {
 		return demo4();
 	})
-	.add('Embedded diagram', () => {
+	.add("Embedded diagram", () => {
 		return demo5();
 	})
-	.add('Serializing and Deserializing', () => {
+	.add("Serializing and Deserializing", () => {
 		return demo6();
 	})
-	.add('Grid Size', () => {
+	.add("Grid Size", () => {
 		return demo7();
-	})
+	});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook:build": "build-storybook -c .storybook -o .out",
     "storybook:github": "storybook-to-ghpages",
-    "prepublishOnly": "export NODE_ENV=production && webpack && ./node_modules/node-sass/bin/node-sass --output-style compressed ./src/sass.scss > ./dist/style.css"
+    "prepublishOnly": "export NODE_ENV=production && webpack && ./node_modules/node-sass/bin/node-sass --output-style compressed ./src/sass.scss > ./dist/style.css",
+    "lintjs": "prettier --single-quote --trailing-comma es5 --write \"src/**/*.js\""
   },
   "dependencies": {
     "@storybook/storybook-deployer": "^2.0.0",
@@ -40,6 +41,7 @@
     "awesome-typescript-loader": "^3.2.3",
     "css-loader": "^0.28.7",
     "node-sass": "^4.5.3",
+    "prettier": "^1.6.1",
     "react-dom": "^15.6.1",
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "storybook:build": "build-storybook -c .storybook -o .out",
     "storybook:github": "storybook-to-ghpages",
     "prepublishOnly": "export NODE_ENV=production && webpack && ./node_modules/node-sass/bin/node-sass --output-style compressed ./src/sass.scss > ./dist/style.css",
-    "lintjs": "prettier --single-quote --trailing-comma es5 --write \"src/**/*.js\""
+    "lintjs": "prettier --use-tabs --write \"src/**/*.ts\""
   },
   "dependencies": {
     "@storybook/storybook-deployer": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "storybook:build": "build-storybook -c .storybook -o .out",
     "storybook:github": "storybook-to-ghpages",
     "prepublishOnly": "export NODE_ENV=production && webpack && ./node_modules/node-sass/bin/node-sass --output-style compressed ./src/sass.scss > ./dist/style.css",
-    "lintjs": "prettier --use-tabs --write \"src/**/*.ts\""
+    "lintjs": "prettier --use-tabs --write \"{src,demos}/**/*.{ts,tsx}\""
   },
   "dependencies": {
     "@storybook/storybook-deployer": "^2.0.0",

--- a/src/AbstractInstanceFactory.ts
+++ b/src/AbstractInstanceFactory.ts
@@ -1,18 +1,19 @@
-import {BaseEntity, BaseListener} from "./BaseEntity";
+import { BaseEntity, BaseListener } from "./BaseEntity";
 /**
  * @author Dylan Vorster
  */
-export abstract class AbstractInstanceFactory<T extends BaseEntity<BaseListener>>{
-
+export abstract class AbstractInstanceFactory<
+	T extends BaseEntity<BaseListener>
+> {
 	className: string;
 
-	constructor(className: string){
+	constructor(className: string) {
 		this.className = className;
 	}
 
-	getName(){
+	getName() {
 		return this.className;
 	}
 
-	abstract getInstance(initialConfig?:any): T;
+	abstract getInstance(initialConfig?: any): T;
 }

--- a/src/BaseEntity.ts
+++ b/src/BaseEntity.ts
@@ -1,69 +1,68 @@
-import {Toolkit} from "./Toolkit";
+import { Toolkit } from "./Toolkit";
 /**
  * @author Dylan Vorster
  */
-export class BaseListener{
-	lockChanged?(entity: BaseEntity<BaseListener>,locked: boolean): void;
+export class BaseListener {
+	lockChanged?(entity: BaseEntity<BaseListener>, locked: boolean): void;
 }
 
-export class BaseEntity<T extends BaseListener>{
-
-	public listeners:{[s: string]: T};
+export class BaseEntity<T extends BaseListener> {
+	public listeners: { [s: string]: T };
 	public id: string;
 	public locked: boolean;
 
-	constructor(id?:string){
+	constructor(id?: string) {
 		this.listeners = {};
 		this.id = id || Toolkit.UID();
 		this.locked = false;
 	}
 
-	getID(){
+	getID() {
 		return this.id;
 	}
 
-	clearListeners(){
+	clearListeners() {
 		this.listeners = {};
 	}
 
-	public deSerialize(data){
+	public deSerialize(data) {
 		this.id = data.id;
 	}
 
-	public serialize(){
+	public serialize() {
 		return {
-			id: this.id,
-		}
+			id: this.id
+		};
 	}
 
-	public iterateListeners(cb: (t: T) => any){
-		for (var i in this.listeners){
+	public iterateListeners(cb: (t: T) => any) {
+		for (var i in this.listeners) {
 			cb(this.listeners[i]);
 		}
 	}
 
-	public removeListener(listener: string){
-		if (this.listeners[listener]){
+	public removeListener(listener: string) {
+		if (this.listeners[listener]) {
 			delete this.listeners[listener];
 			return true;
 		}
 		return false;
 	}
 
-	public addListener(listener: T): string{
+	public addListener(listener: T): string {
 		var uid = Toolkit.UID();
 		this.listeners[uid] = listener;
 		return uid;
 	}
 
-	public isLocked(): boolean{
+	public isLocked(): boolean {
 		return this.locked;
 	}
 
-	public setLocked(locked: boolean = true){
+	public setLocked(locked: boolean = true) {
 		this.locked = locked;
-		this.iterateListeners((listener) => {
-			if (listener.lockChanged){
+		this.iterateListeners(listener => {
+			if (listener.lockChanged) {
 				listener.lockChanged(this, locked);
 			}
 		});

--- a/src/CanvasActions.ts
+++ b/src/CanvasActions.ts
@@ -1,7 +1,7 @@
-import {DiagramModel} from "./DiagramModel";
-import {DiagramEngine} from "./DiagramEngine";
-import {NodeModel, PointModel} from "./Common";
-import {SelectionModel} from "./widgets/DiagramWidget";
+import { DiagramModel } from "./DiagramModel";
+import { DiagramEngine } from "./DiagramEngine";
+import { NodeModel, PointModel } from "./Common";
+import { SelectionModel } from "./widgets/DiagramWidget";
 
 export class BaseAction {
 	mouseX: number;
@@ -11,7 +11,7 @@ export class BaseAction {
 	constructor(mouseX: number, mouseY: number) {
 		this.mouseX = mouseX;
 		this.mouseY = mouseY;
-		this.ms = (new Date()).getTime();
+		this.ms = new Date().getTime();
 	}
 }
 
@@ -25,14 +25,14 @@ export class SelectingAction extends BaseAction {
 		this.mouseY2 = mouseY;
 	}
 
-	getBoxDimensions(){
+	getBoxDimensions() {
 		return {
 			left: this.mouseX2 > this.mouseX ? this.mouseX : this.mouseX2,
 			top: this.mouseY2 > this.mouseY ? this.mouseY : this.mouseY2,
-			width: Math.abs(this.mouseX2-this.mouseX),
-			height: Math.abs(this.mouseY2-this.mouseY),
+			width: Math.abs(this.mouseX2 - this.mouseX),
+			height: Math.abs(this.mouseY2 - this.mouseY),
 			right: this.mouseX2 < this.mouseX ? this.mouseX : this.mouseX2,
-			bottom: this.mouseY2 < this.mouseY ? this.mouseY : this.mouseY2,
+			bottom: this.mouseY2 < this.mouseY ? this.mouseY : this.mouseY2
 		};
 	}
 
@@ -48,7 +48,7 @@ export class SelectingAction extends BaseAction {
 			(x + diagramModel.getOffsetX()) * z < dimensions.right &&
 			(y + diagramModel.getOffsetY()) * z > dimensions.top &&
 			(y + diagramModel.getOffsetY()) * z < dimensions.bottom
-		)
+		);
 	}
 }
 
@@ -70,20 +70,22 @@ export class MoveItemsAction extends BaseAction {
 	constructor(mouseX: number, mouseY: number, diagramEngine: DiagramEngine) {
 		super(mouseX, mouseY);
 		this.moved = false;
-		diagramEngine.enableRepaintEntities(diagramEngine.getDiagramModel().getSelectedItems());
+		diagramEngine.enableRepaintEntities(
+			diagramEngine.getDiagramModel().getSelectedItems()
+		);
 		var selectedItems = diagramEngine.getDiagramModel().getSelectedItems();
 
 		//dont allow items which are locked to move
-		selectedItems = selectedItems.filter((item) => {
+		selectedItems = selectedItems.filter(item => {
 			return !diagramEngine.isModelLocked(item);
-		})
+		});
 
 		this.selectionModels = selectedItems.map((item: PointModel | NodeModel) => {
 			return {
 				model: item,
 				initialX: item.x,
-				initialY: item.y,
-			}
+				initialY: item.y
+			};
 		});
 	}
 }

--- a/src/Common.ts
+++ b/src/Common.ts
@@ -1,205 +1,205 @@
-import {BaseEntity, BaseListener} from "./BaseEntity";
+import { BaseEntity, BaseListener } from "./BaseEntity";
 import * as _ from "lodash";
 
-export interface BaseModelListener extends BaseListener{
+export interface BaseModelListener extends BaseListener {
+	selectionChanged?(
+		item: BaseModel<BaseModelListener>,
+		isSelected: boolean
+	): void;
 
-	selectionChanged?(item: BaseModel<BaseModelListener>, isSelected:boolean): void;
-
-	entityRemoved?(item:any): void;
+	entityRemoved?(item: any): void;
 }
 
 /**
  * @author Dylan Vorster
  */
-export class BaseModel<T extends BaseModelListener> extends BaseEntity<BaseModelListener>{
-
+export class BaseModel<T extends BaseModelListener> extends BaseEntity<
+	BaseModelListener
+> {
 	selected: boolean;
 
-	constructor(id?:string){
+	constructor(id?: string) {
 		super(id);
 		this.selected = false;
 	}
 
-	deSerialize(ob){
+	deSerialize(ob) {
 		super.deSerialize(ob);
 		this.selected = ob.selected;
 	}
 
-	serialize(){
-		return _.merge(super.serialize(),{
+	serialize() {
+		return _.merge(super.serialize(), {
 			_class: this.constructor.name,
 			selected: this.selected
 		});
 	}
 
-	public getID(): string{
-		return this.id
+	public getID(): string {
+		return this.id;
 	}
 
-	public isSelected(): boolean{
+	public isSelected(): boolean {
 		return this.selected;
 	}
 
-	public setSelected(selected: boolean = true){
+	public setSelected(selected: boolean = true) {
 		this.selected = selected;
-		this.iterateListeners((listener) => {
-			if(listener.selectionChanged){
+		this.iterateListeners(listener => {
+			if (listener.selectionChanged) {
 				listener.selectionChanged(this, selected);
 			}
 		});
 	}
 
-	remove(){
-		this.iterateListeners((listener) => {
-			if(listener.entityRemoved){
+	remove() {
+		this.iterateListeners(listener => {
+			if (listener.entityRemoved) {
 				listener.entityRemoved(this);
 			}
 		});
 	}
 }
 
-export class PointModel extends BaseModel<BaseModelListener>{
-
-	x:number;
-	y:number;
+export class PointModel extends BaseModel<BaseModelListener> {
+	x: number;
+	y: number;
 	link: LinkModel;
 
-	constructor(link: LinkModel,points: {x:number,y: number}){
+	constructor(link: LinkModel, points: { x: number; y: number }) {
 		super();
 		this.x = points.x;
 		this.y = points.y;
 		this.link = link;
 	}
 
-	deSerialize(ob){
+	deSerialize(ob) {
 		super.deSerialize(ob);
 		this.x = ob.x;
 		this.y = ob.y;
 	}
 
-	serialize(){
-		return _.merge(super.serialize(),{
+	serialize() {
+		return _.merge(super.serialize(), {
 			x: this.x,
 			y: this.y
 		});
 	}
 
-	remove(){
+	remove() {
 		super.remove();
 
 		//clear references
-		if (this.link){
+		if (this.link) {
 			this.link.removePoint(this);
 		}
 	}
 
-	updateLocation(points: {x:number,y: number}){
+	updateLocation(points: { x: number; y: number }) {
 		this.x = points.x;
 		this.y = points.y;
 	}
 
-	getX():number{
+	getX(): number {
 		return this.x;
 	}
 
-	getY():number{
+	getY(): number {
 		return this.y;
 	}
 
-	getLink(): LinkModel{
+	getLink(): LinkModel {
 		return this.link;
 	}
 }
 
-export interface LinkModelListener extends BaseModelListener{
+export interface LinkModelListener extends BaseModelListener {
+	sourcePortChanged?(item: LinkModel, target: null | PortModel): void;
 
-	sourcePortChanged?(item:LinkModel,target: null|PortModel): void;
-
-	targetPortChanged?(item:LinkModel,target: null|PortModel): void;
+	targetPortChanged?(item: LinkModel, target: null | PortModel): void;
 }
 
-export class LinkModel extends BaseModel<LinkModelListener>{
-
+export class LinkModel extends BaseModel<LinkModelListener> {
 	linkType: string;
-	sourcePort: PortModel|null;
-	targetPort: PortModel|null;
+	sourcePort: PortModel | null;
+	targetPort: PortModel | null;
 	points: PointModel[];
 	extras: {};
 
-	constructor(){
+	constructor() {
 		super();
-		this.linkType = 'default';
+		this.linkType = "default";
 		this.points = [
-			new PointModel(this,{x: 0,y: 0}),
-			new PointModel(this,{x: 0,y: 0}),
+			new PointModel(this, { x: 0, y: 0 }),
+			new PointModel(this, { x: 0, y: 0 })
 		];
 		this.extras = {};
 		this.sourcePort = null;
 		this.targetPort = null;
 	}
 
-	deSerialize(ob){
+	deSerialize(ob) {
 		super.deSerialize(ob);
 		this.linkType = ob.type;
 		this.extras = ob.extras;
-		this.points = _.map(ob.points,(point: {x,y}) => {
-			var p = new PointModel(this, {x: point.x,y:point.y});
+		this.points = _.map(ob.points, (point: { x; y }) => {
+			var p = new PointModel(this, { x: point.x, y: point.y });
 			p.deSerialize(point);
 			return p;
-		})
+		});
 	}
 
-	serialize(){
-		return _.merge(super.serialize(),{
+	serialize() {
+		return _.merge(super.serialize(), {
 			type: this.linkType,
-			source: this.sourcePort ? this.sourcePort.getParent().id:null,
-			sourcePort: this.sourcePort ? this.sourcePort.id:null,
-			target: this.targetPort ? this.targetPort.getParent().id:null,
-			targetPort: this.targetPort ? this.targetPort.id:null,
-			points: _.map(this.points,(point) => {
+			source: this.sourcePort ? this.sourcePort.getParent().id : null,
+			sourcePort: this.sourcePort ? this.sourcePort.id : null,
+			target: this.targetPort ? this.targetPort.getParent().id : null,
+			targetPort: this.targetPort ? this.targetPort.id : null,
+			points: _.map(this.points, point => {
 				return point.serialize();
 			}),
 			extras: this.extras
 		});
 	}
 
-	remove(){
+	remove() {
 		super.remove();
-		if (this.sourcePort){
+		if (this.sourcePort) {
 			this.sourcePort.removeLink(this);
 		}
-		if (this.targetPort){
+		if (this.targetPort) {
 			this.targetPort.removeLink(this);
 		}
 	}
 
-	isLastPoint(point: PointModel){
+	isLastPoint(point: PointModel) {
 		var index = this.getPointIndex(point);
-		return index === this.points.length-1;
+		return index === this.points.length - 1;
 	}
 
-	getPointIndex(point: PointModel){
+	getPointIndex(point: PointModel) {
 		return this.points.indexOf(point);
 	}
 
-	getPointModel(id: string): PointModel|null{
-		for (var i = 0; i < this.points.length;i++){
-			if (this.points[i].id === id){
+	getPointModel(id: string): PointModel | null {
+		for (var i = 0; i < this.points.length; i++) {
+			if (this.points[i].id === id) {
 				return this.points[i];
 			}
 		}
 		return null;
 	}
 
-	getFirstPoint(): PointModel{
+	getFirstPoint(): PointModel {
 		return this.points[0];
 	}
 
-	getLastPoint(): PointModel{
-		return this.points[this.points.length-1];
+	getLastPoint(): PointModel {
+		return this.points[this.points.length - 1];
 	}
 
-	setSourcePort(port: PortModel){
+	setSourcePort(port: PortModel) {
 		port.addLink(this);
 		this.sourcePort = port;
 		this.iterateListeners((listener: LinkModelListener) => {
@@ -207,15 +207,15 @@ export class LinkModel extends BaseModel<LinkModelListener>{
 		});
 	}
 
-	getSourcePort(): PortModel{
+	getSourcePort(): PortModel {
 		return this.sourcePort;
 	}
 
-	getTargetPort(): PortModel{
+	getTargetPort(): PortModel {
 		return this.targetPort;
 	}
 
-	setTargetPort(port: PortModel){
+	setTargetPort(port: PortModel) {
 		port.addLink(this);
 		this.targetPort = port;
 		this.iterateListeners((listener: LinkModelListener) => {
@@ -223,88 +223,87 @@ export class LinkModel extends BaseModel<LinkModelListener>{
 		});
 	}
 
-	getPoints(): PointModel[]{
+	getPoints(): PointModel[] {
 		return this.points;
 	}
 
-	setPoints(points: PointModel[]){
+	setPoints(points: PointModel[]) {
 		this.points = points;
 	}
 
-	removePoint(pointModel: PointModel){
-		this.points.splice(this.getPointIndex(pointModel),1);
+	removePoint(pointModel: PointModel) {
+		this.points.splice(this.getPointIndex(pointModel), 1);
 	}
 
-	addPoint(pointModel:PointModel,index = 1){
-		this.points.splice(index,0,pointModel);
+	addPoint(pointModel: PointModel, index = 1) {
+		this.points.splice(index, 0, pointModel);
 	}
 
-	getType(): string{
+	getType(): string {
 		return this.linkType;
 	}
 }
 
-export class PortModel extends BaseModel<BaseModelListener>{
+export class PortModel extends BaseModel<BaseModelListener> {
 	name: string;
 	parentNode: NodeModel;
-	links: {[id: string]: LinkModel};
+	links: { [id: string]: LinkModel };
 
-	deSerialize(ob){
+	deSerialize(ob) {
 		super.deSerialize(ob);
 		this.name = ob.name;
 	}
 
-	serialize(){
-		return _.merge(super.serialize(),{
+	serialize() {
+		return _.merge(super.serialize(), {
 			name: this.name,
 			parentNode: this.parentNode.id,
-			links: _.map(this.links,(link) => {
+			links: _.map(this.links, link => {
 				return link.id;
 			})
 		});
 	}
 
-	constructor(name: string, id?:string){
+	constructor(name: string, id?: string) {
 		super(id);
 		this.name = name;
 		this.links = {};
 		this.parentNode = null;
 	}
 
-	getName(): string{
+	getName(): string {
 		return this.name;
 	}
 
-	getParent(): NodeModel{
+	getParent(): NodeModel {
 		return this.parentNode;
 	}
 
-	setParentNode(node: NodeModel){
+	setParentNode(node: NodeModel) {
 		this.parentNode = node;
 	}
 
-	removeLink(link: LinkModel){
+	removeLink(link: LinkModel) {
 		delete this.links[link.getID()];
 	}
 
-	addLink(link: LinkModel){
+	addLink(link: LinkModel) {
 		this.links[link.getID()] = link;
 	}
 
-	getLinks(): {[id: string]: LinkModel}{
+	getLinks(): { [id: string]: LinkModel } {
 		return this.links;
 	}
 }
 
-export class NodeModel extends BaseModel<BaseModelListener>{
-
+export class NodeModel extends BaseModel<BaseModelListener> {
 	nodeType: string;
 	x: number;
 	y: number;
 	extras: {};
-	ports:  {[s: string]:PortModel};
+	ports: { [s: string]: PortModel };
 
-	constructor(nodeType: string = 'default', id?:string){
+	constructor(nodeType: string = "default", id?: string) {
 		super(id);
 		this.nodeType = nodeType;
 		this.x = 0;
@@ -313,7 +312,7 @@ export class NodeModel extends BaseModel<BaseModelListener>{
 		this.ports = {};
 	}
 
-	deSerialize(ob){
+	deSerialize(ob) {
 		super.deSerialize(ob);
 		this.nodeType = ob.type;
 		this.x = ob.x;
@@ -321,59 +320,59 @@ export class NodeModel extends BaseModel<BaseModelListener>{
 		this.extras = ob.extras;
 	}
 
-	serialize(){
-		return _.merge(super.serialize(),{
+	serialize() {
+		return _.merge(super.serialize(), {
 			type: this.nodeType,
 			x: this.x,
 			y: this.y,
 			extras: this.extras,
-			ports: _.map(this.ports,(port) => {
-				return port.serialize()
+			ports: _.map(this.ports, port => {
+				return port.serialize();
 			})
 		});
 	}
 
-	remove(){
+	remove() {
 		super.remove();
-		for (var i in this.ports){
-			_.forEach(this.ports[i].getLinks(),(link) => {
+		for (var i in this.ports) {
+			_.forEach(this.ports[i].getLinks(), link => {
 				link.remove();
 			});
 		}
 	}
 
-	getPortFromID(id): PortModel | null{
-		for (var i in this.ports){
-			if (this.ports[i].id === id){
+	getPortFromID(id): PortModel | null {
+		for (var i in this.ports) {
+			if (this.ports[i].id === id) {
 				return this.ports[i];
 			}
 		}
 		return null;
 	}
 
-	getPort(name: string): PortModel | null{
+	getPort(name: string): PortModel | null {
 		return this.ports[name];
 	}
 
-	getPorts(): {[s: string]:PortModel}{
+	getPorts(): { [s: string]: PortModel } {
 		return this.ports;
 	}
 
-	removePort(port: PortModel){
+	removePort(port: PortModel) {
 		//clear the parent node reference
-		if(this.ports[port.name]){
+		if (this.ports[port.name]) {
 			this.ports[port.name].setParentNode(null);
 			delete this.ports[port.name];
 		}
 	}
 
-	addPort(port: PortModel): PortModel{
+	addPort(port: PortModel): PortModel {
 		port.setParentNode(this);
 		this.ports[port.name] = port;
 		return port;
 	}
 
-	getType(): string{
+	getType(): string {
 		return this.nodeType;
 	}
 }

--- a/src/DiagramEngine.ts
+++ b/src/DiagramEngine.ts
@@ -1,14 +1,20 @@
-import {NodeWidgetFactory, LinkWidgetFactory} from "./WidgetFactories";
-import {LinkModel, NodeModel, BaseModel,BaseModelListener, PortModel, PointModel} from "./Common";
-import {BaseEntity, BaseListener} from "./BaseEntity";
-import {DiagramModel} from "./DiagramModel";
-import {AbstractInstanceFactory} from "./AbstractInstanceFactory";
+import { NodeWidgetFactory, LinkWidgetFactory } from "./WidgetFactories";
+import {
+	LinkModel,
+	NodeModel,
+	BaseModel,
+	BaseModelListener,
+	PortModel,
+	PointModel
+} from "./Common";
+import { BaseEntity, BaseListener } from "./BaseEntity";
+import { DiagramModel } from "./DiagramModel";
+import { AbstractInstanceFactory } from "./AbstractInstanceFactory";
 import * as _ from "lodash";
 /**
  * @author Dylan Vorster
  */
-export interface DiagramEngineListener extends BaseListener{
-
+export interface DiagramEngineListener extends BaseListener {
 	nodeFactoriesUpdated?(): void;
 
 	linkFactoriesUpdated?(): void;
@@ -19,17 +25,18 @@ export interface DiagramEngineListener extends BaseListener{
 /**
  * Passed as a parameter to the DiagramWidget
  */
-export class DiagramEngine extends BaseEntity<DiagramEngineListener>{
-
-	nodeFactories: {[s: string]:NodeWidgetFactory};
-	linkFactories: {[s: string]:LinkWidgetFactory};
-	instanceFactories: {[s: string]: AbstractInstanceFactory<BaseEntity<BaseListener>>};
+export class DiagramEngine extends BaseEntity<DiagramEngineListener> {
+	nodeFactories: { [s: string]: NodeWidgetFactory };
+	linkFactories: { [s: string]: LinkWidgetFactory };
+	instanceFactories: {
+		[s: string]: AbstractInstanceFactory<BaseEntity<BaseListener>>;
+	};
 
 	diagramModel: DiagramModel;
 	canvas: Element;
 	paintableWidgets: {};
 
-	constructor(){
+	constructor() {
 		super();
 		this.diagramModel = new DiagramModel();
 		this.nodeFactories = {};
@@ -39,30 +46,29 @@ export class DiagramEngine extends BaseEntity<DiagramEngineListener>{
 		this.paintableWidgets = null;
 	}
 
-	repaintCanvas(){
-		this.iterateListeners((listener) => {
+	repaintCanvas() {
+		this.iterateListeners(listener => {
 			listener.repaintCanvas && listener.repaintCanvas();
-		})
+		});
 	}
 
-	clearRepaintEntities(){
+	clearRepaintEntities() {
 		this.paintableWidgets = null;
 	}
 
-	enableRepaintEntities(entities: BaseModel<BaseModelListener>[]){
+	enableRepaintEntities(entities: BaseModel<BaseModelListener>[]) {
 		this.paintableWidgets = {};
-		entities.forEach((entity) => {
-
+		entities.forEach(entity => {
 			//if a node is requested to repaint, add all of its links
-			if (entity instanceof NodeModel){
-				_.forEach(entity.getPorts(),(port) => {
-					_.forEach(port.getLinks(),(link) => {
+			if (entity instanceof NodeModel) {
+				_.forEach(entity.getPorts(), port => {
+					_.forEach(port.getLinks(), link => {
 						this.paintableWidgets[link.getID()] = true;
 					});
 				});
 			}
 
-			if (entity instanceof PointModel){
+			if (entity instanceof PointModel) {
 				this.paintableWidgets[entity.getLink().getID()] = true;
 			}
 
@@ -74,23 +80,22 @@ export class DiagramEngine extends BaseEntity<DiagramEngineListener>{
 	 * Checks to see if a model is locked by running through
 	 * its parents to see if they are locked first
 	 */
-	isModelLocked(model: BaseEntity<BaseListener>){
-
+	isModelLocked(model: BaseEntity<BaseListener>) {
 		//always check the diagram model
-		if (this.diagramModel.isLocked()){
+		if (this.diagramModel.isLocked()) {
 			return true;
 		}
 
 		//a point is locked, if its model is locked
-		if (model instanceof PortModel){
-			if (model.getParent().isLocked()){
+		if (model instanceof PortModel) {
+			if (model.getParent().isLocked()) {
 				return true;
 			}
 		}
 
 		//a point is locked, if its model is locked
-		if (model instanceof PointModel){
-			if (model.getLink().isLocked()){
+		if (model instanceof PointModel) {
+			if (model.getLink().isLocked()) {
 				return true;
 			}
 		}
@@ -98,120 +103,147 @@ export class DiagramEngine extends BaseEntity<DiagramEngineListener>{
 		return model.isLocked();
 	}
 
-	canEntityRepaint(baseModel: BaseModel<BaseModelListener>){
+	canEntityRepaint(baseModel: BaseModel<BaseModelListener>) {
 		//no rules applied, allow repaint
-		if(this.paintableWidgets === null){
+		if (this.paintableWidgets === null) {
 			return true;
 		}
 
 		return this.paintableWidgets[baseModel.getID()] !== undefined;
 	}
 
-	setCanvas(canvas: Element| null){
+	setCanvas(canvas: Element | null) {
 		this.canvas = canvas;
 	}
 
-	setDiagramModel(model: DiagramModel){
+	setDiagramModel(model: DiagramModel) {
 		this.diagramModel = model;
 	}
 
-	getDiagramModel(): DiagramModel{
+	getDiagramModel(): DiagramModel {
 		return this.diagramModel;
 	}
 
-	getNodeFactories(): {[s: string]:NodeWidgetFactory}{
+	getNodeFactories(): { [s: string]: NodeWidgetFactory } {
 		return this.nodeFactories;
 	}
 
-	getLinkFactories(): {[s: string]:LinkWidgetFactory}{
+	getLinkFactories(): { [s: string]: LinkWidgetFactory } {
 		return this.linkFactories;
 	}
 
-	getInstanceFactory(className: string): AbstractInstanceFactory<BaseEntity<BaseListener>>{
+	getInstanceFactory(
+		className: string
+	): AbstractInstanceFactory<BaseEntity<BaseListener>> {
 		return this.instanceFactories[className];
 	}
 
-	registerInstanceFactory(factory: AbstractInstanceFactory<BaseEntity<BaseListener>>){
+	registerInstanceFactory(
+		factory: AbstractInstanceFactory<BaseEntity<BaseListener>>
+	) {
 		this.instanceFactories[factory.getName()] = factory;
 	}
 
-	registerNodeFactory(factory: NodeWidgetFactory){
+	registerNodeFactory(factory: NodeWidgetFactory) {
 		this.nodeFactories[factory.getType()] = factory;
-		this.iterateListeners((listener) => {
-			if(listener.nodeFactoriesUpdated) listener.nodeFactoriesUpdated();
+		this.iterateListeners(listener => {
+			if (listener.nodeFactoriesUpdated) listener.nodeFactoriesUpdated();
 		});
 	}
 
-	registerLinkFactory(factory: LinkWidgetFactory){
+	registerLinkFactory(factory: LinkWidgetFactory) {
 		this.linkFactories[factory.getType()] = factory;
-		this.iterateListeners((listener) => {
-			if(listener.linkFactoriesUpdated) listener.linkFactoriesUpdated();
+		this.iterateListeners(listener => {
+			if (listener.linkFactoriesUpdated) listener.linkFactoriesUpdated();
 		});
 	}
 
-	getFactoryForNode(node: NodeModel): NodeWidgetFactory | null{
-		if (this.nodeFactories[node.getType()]){
+	getFactoryForNode(node: NodeModel): NodeWidgetFactory | null {
+		if (this.nodeFactories[node.getType()]) {
 			return this.nodeFactories[node.getType()];
 		}
-		console.log("cannot find widget factory for node of type: [" + node.getType()+"]");
+		console.log(
+			"cannot find widget factory for node of type: [" + node.getType() + "]"
+		);
 		return null;
 	}
 
-	getFactoryForLink(link: LinkModel): LinkWidgetFactory | null{
-		if (this.linkFactories[link.getType()]){
+	getFactoryForLink(link: LinkModel): LinkWidgetFactory | null {
+		if (this.linkFactories[link.getType()]) {
 			return this.linkFactories[link.getType()];
 		}
-		console.log("cannot find widget factory for link of type: [" + link.getType()+"]");
+		console.log(
+			"cannot find widget factory for link of type: [" + link.getType() + "]"
+		);
 		return null;
 	}
 
-	generateWidgetForLink(link: LinkModel): JSX.Element|null{
+	generateWidgetForLink(link: LinkModel): JSX.Element | null {
 		var linkFactory = this.getFactoryForLink(link);
-		if(!linkFactory){
+		if (!linkFactory) {
 			throw "Cannot find link factory for link: " + link.getType();
 		}
-		return linkFactory.generateReactWidget(this,link);
+		return linkFactory.generateReactWidget(this, link);
 	}
 
-	generateWidgetForNode(node: NodeModel): JSX.Element|null{
+	generateWidgetForNode(node: NodeModel): JSX.Element | null {
 		var nodeFactory = this.getFactoryForNode(node);
-		if(!nodeFactory){
+		if (!nodeFactory) {
 			throw "Cannot find widget factory for node: " + node.getType();
 		}
-		return nodeFactory.generateReactWidget(this,node);
+		return nodeFactory.generateReactWidget(this, node);
 	}
 
-	getRelativeMousePoint(event): {x:number,y:number}{
-		var point = this.getRelativePoint(event.clientX,event.clientY);
+	getRelativeMousePoint(event): { x: number; y: number } {
+		var point = this.getRelativePoint(event.clientX, event.clientY);
 		return {
-			x: (point.x / (this.diagramModel.getZoomLevel() / 100.0)) - this.diagramModel.getOffsetX(),
-			y: (point.y / (this.diagramModel.getZoomLevel() / 100.0)) - this.diagramModel.getOffsetY()
+			x:
+				point.x / (this.diagramModel.getZoomLevel() / 100.0) -
+				this.diagramModel.getOffsetX(),
+			y:
+				point.y / (this.diagramModel.getZoomLevel() / 100.0) -
+				this.diagramModel.getOffsetY()
 		};
 	}
 
-	getRelativePoint(x,y){
+	getRelativePoint(x, y) {
 		var canvasRect = this.canvas.getBoundingClientRect();
-		return {x: x-canvasRect.left,y:y-canvasRect.top};
+		return { x: x - canvasRect.left, y: y - canvasRect.top };
 	}
 
-	getNodePortElement(port: PortModel): any{
-		var selector = this.canvas.querySelector('.port[data-name="' + port.getName() + '"][data-nodeid="' + port.getParent().getID()+'"]');
-		if(selector === null){
-			throw "Cannot find Node Port element with nodeID: [" + port.getParent().getID()+"] and name: ["+port.getName()+"]";
+	getNodePortElement(port: PortModel): any {
+		var selector = this.canvas.querySelector(
+			'.port[data-name="' +
+				port.getName() +
+				'"][data-nodeid="' +
+				port.getParent().getID() +
+				'"]'
+		);
+		if (selector === null) {
+			throw "Cannot find Node Port element with nodeID: [" +
+				port.getParent().getID() +
+				"] and name: [" +
+				port.getName() +
+				"]";
 		}
 		return selector;
 	}
 
-	getPortCenter(port: PortModel){
+	getPortCenter(port: PortModel) {
 		var sourceElement = this.getNodePortElement(port);
 		var sourceRect = sourceElement.getBoundingClientRect();
 
-		var rel = this.getRelativePoint(sourceRect.left,sourceRect.top);
+		var rel = this.getRelativePoint(sourceRect.left, sourceRect.top);
 
 		return {
-			x: ((sourceElement.offsetWidth / 2) + rel.x / (this.diagramModel.getZoomLevel() / 100.0)) - this.diagramModel.getOffsetX(),
-			y: ((sourceElement.offsetHeight/2)+rel.y/(this.diagramModel.getZoomLevel()/100.0)) - this.diagramModel.getOffsetY()
+			x:
+				sourceElement.offsetWidth / 2 +
+				rel.x / (this.diagramModel.getZoomLevel() / 100.0) -
+				this.diagramModel.getOffsetX(),
+			y:
+				sourceElement.offsetHeight / 2 +
+				rel.y / (this.diagramModel.getZoomLevel() / 100.0) -
+				this.diagramModel.getOffsetY()
 		};
 	}
-
 }

--- a/src/DiagramModel.ts
+++ b/src/DiagramModel.ts
@@ -1,36 +1,40 @@
-import {LinkModel, NodeModel, BaseModel,BaseModelListener, PortModel} from "./Common";
-import {BaseListener, BaseEntity} from "./BaseEntity";
+import {
+	LinkModel,
+	NodeModel,
+	BaseModel,
+	BaseModelListener,
+	PortModel
+} from "./Common";
+import { BaseListener, BaseEntity } from "./BaseEntity";
 import * as _ from "lodash";
-import {DiagramEngine} from "./DiagramEngine";
+import { DiagramEngine } from "./DiagramEngine";
 /**
  * @author Dylan Vorster
  *
  */
-export interface DiagramListener extends BaseListener{
+export interface DiagramListener extends BaseListener {
+	nodesUpdated?(node: any, isCreated: boolean): void;
 
-	nodesUpdated?(node: any, isCreated:boolean): void;
-
-	linksUpdated?(link: any, isCreated:boolean): void;
+	linksUpdated?(link: any, isCreated: boolean): void;
 
 	/**
 	 * @deprecated
 	 */
 	controlsUpdated?(): void;
 
-	offsetUpdated?(model: DiagramModel,offsetX: number, offsetY: number): void;
+	offsetUpdated?(model: DiagramModel, offsetX: number, offsetY: number): void;
 
-	zoomUpdated?(model: DiagramModel,zoom: number): void;
+	zoomUpdated?(model: DiagramModel, zoom: number): void;
 
-	gridUpdated?(model: DiagramModel,size: number): void;
+	gridUpdated?(model: DiagramModel, size: number): void;
 }
 /**
  *
  */
-export class DiagramModel extends BaseEntity<DiagramListener>{
-
+export class DiagramModel extends BaseEntity<DiagramListener> {
 	//models
-	links: {[s:string] : LinkModel};
-	nodes: {[s:string] : NodeModel};
+	links: { [s: string]: LinkModel };
+	nodes: { [s: string]: NodeModel };
 
 	//control variables
 	offsetX: number;
@@ -39,7 +43,7 @@ export class DiagramModel extends BaseEntity<DiagramListener>{
 	rendered: boolean;
 	gridSize: number;
 
-	constructor(){
+	constructor() {
 		super();
 
 		this.links = {};
@@ -52,35 +56,38 @@ export class DiagramModel extends BaseEntity<DiagramListener>{
 		this.gridSize = 0;
 	}
 
-	setGridSize(size: number = 0){
+	setGridSize(size: number = 0) {
 		this.gridSize = size;
-		this.iterateListeners((listener) => {
+		this.iterateListeners(listener => {
 			listener.gridUpdated && listener.gridUpdated(this, size);
-		})
+		});
 	}
 
-	getGridPosition(pos){
-		if(this.gridSize === 0){
+	getGridPosition(pos) {
+		if (this.gridSize === 0) {
 			return pos;
 		}
-		return this.gridSize * Math.floor(pos/this.gridSize);
+		return this.gridSize * Math.floor(pos / this.gridSize);
 	}
 
-	deSerializeDiagram(object: any, diagramEngine: DiagramEngine){
+	deSerializeDiagram(object: any, diagramEngine: DiagramEngine) {
 		this.deSerialize(object);
 
 		this.offsetX = object.offsetX;
 		this.offsetY = object.offsetY;
 		this.zoom = object.zoom;
 
-
 		//deserialize nodes
-		_.forEach(object.nodes,(node: any) => {
-			let nodeOb = diagramEngine.getInstanceFactory(node._class).getInstance(node) as NodeModel;
+		_.forEach(object.nodes, (node: any) => {
+			let nodeOb = diagramEngine
+				.getInstanceFactory(node._class)
+				.getInstance(node) as NodeModel;
 			nodeOb.deSerialize(node);
 			//deserialize ports
-			_.forEach(node.ports,(port: any) => {
-				let portOb = diagramEngine.getInstanceFactory(port._class).getInstance() as PortModel;
+			_.forEach(node.ports, (port: any) => {
+				let portOb = diagramEngine
+					.getInstanceFactory(port._class)
+					.getInstance() as PortModel;
 				portOb.deSerialize(port);
 				nodeOb.addPort(portOb);
 			});
@@ -88,197 +95,215 @@ export class DiagramModel extends BaseEntity<DiagramListener>{
 			this.addNode(nodeOb);
 		});
 
-		_.forEach(object.links,(link: any) => {
-			let linkOb = diagramEngine.getInstanceFactory(link._class).getInstance() as LinkModel;
+		_.forEach(object.links, (link: any) => {
+			let linkOb = diagramEngine
+				.getInstanceFactory(link._class)
+				.getInstance() as LinkModel;
 			linkOb.deSerialize(link);
 
-			if(link.target){
-				linkOb.setTargetPort(this.getNode(link.target).getPortFromID(link.targetPort));
+			if (link.target) {
+				linkOb.setTargetPort(
+					this.getNode(link.target).getPortFromID(link.targetPort)
+				);
 			}
 
-			if(link.source){
-				linkOb.setSourcePort(this.getNode(link.source).getPortFromID(link.sourcePort))
+			if (link.source) {
+				linkOb.setSourcePort(
+					this.getNode(link.source).getPortFromID(link.sourcePort)
+				);
 			}
 
 			this.addLink(linkOb);
 		});
 	}
 
-	serializeDiagram(){
-		return _.merge(this.serialize(),{
+	serializeDiagram() {
+		return _.merge(this.serialize(), {
 			offsetX: this.offsetX,
 			offsetY: this.offsetY,
 			zoom: this.zoom,
-			links: _.map(this.links,(link) => {
+			links: _.map(this.links, link => {
 				return link.serialize();
 			}),
-			nodes: _.map(this.nodes,(link) => {
+			nodes: _.map(this.nodes, link => {
 				return link.serialize();
-			}),
+			})
 		});
 	}
 
-	clearSelection(ignore: BaseModel<BaseModelListener>|null = null){
-		_.forEach(this.getSelectedItems(),(element) => {
-			if (ignore && ignore.getID() === element.getID()){
+	clearSelection(ignore: BaseModel<BaseModelListener> | null = null) {
+		_.forEach(this.getSelectedItems(), element => {
+			if (ignore && ignore.getID() === element.getID()) {
 				return;
 			}
 			element.setSelected(false); //TODO dont fire the listener
 		});
 	}
 
-	getSelectedItems(): BaseModel<BaseModelListener>[]{
-		var items  = [];
+	getSelectedItems(): BaseModel<BaseModelListener>[] {
+		var items = [];
 
 		//find all nodes
-		items = items.concat(_.filter(this.nodes,(node) => {
-			return node.isSelected();
-		}));
+		items = items.concat(
+			_.filter(this.nodes, node => {
+				return node.isSelected();
+			})
+		);
 
 		//find all points
-		items = items.concat(_.filter(_.flatMap(this.links,(node) => {
-			return node.points;
-		}),(port) => {
-			return port.isSelected();
-		}));
+		items = items.concat(
+			_.filter(
+				_.flatMap(this.links, node => {
+					return node.points;
+				}),
+				port => {
+					return port.isSelected();
+				}
+			)
+		);
 
 		//find all links
-		return items.concat(_.filter(this.links,(link) => {
-			return link.isSelected();
-		}));
+		return items.concat(
+			_.filter(this.links, link => {
+				return link.isSelected();
+			})
+		);
 	}
 
-	setZoomLevel(zoom:number){
+	setZoomLevel(zoom: number) {
 		this.zoom = zoom;
-		this.iterateListeners((listener) => {
-			if(listener.controlsUpdated) listener.controlsUpdated();
+		this.iterateListeners(listener => {
+			if (listener.controlsUpdated) listener.controlsUpdated();
 		});
-		this.iterateListeners((listener) => {
-			listener.zoomUpdated && listener.zoomUpdated(this,this.zoom);
+		this.iterateListeners(listener => {
+			listener.zoomUpdated && listener.zoomUpdated(this, this.zoom);
 		});
 	}
 
-	setOffset(offsetX: number, offsetY: number){
+	setOffset(offsetX: number, offsetY: number) {
 		this.offsetX = offsetX;
 		this.offsetY = offsetY;
-		this.iterateListeners((listener) => {
-			if(listener.controlsUpdated) listener.controlsUpdated();
+		this.iterateListeners(listener => {
+			if (listener.controlsUpdated) listener.controlsUpdated();
 		});
-		this.iterateListeners((listener) => {
-			listener.offsetUpdated && listener.offsetUpdated(this,this.offsetX, this.offsetY)
+		this.iterateListeners(listener => {
+			listener.offsetUpdated &&
+				listener.offsetUpdated(this, this.offsetX, this.offsetY);
 		});
 	}
 
-	setOffsetX(offsetX: number){
+	setOffsetX(offsetX: number) {
 		this.offsetX = offsetX;
-		this.iterateListeners((listener) => {
-			if(listener.controlsUpdated) listener.controlsUpdated();
+		this.iterateListeners(listener => {
+			if (listener.controlsUpdated) listener.controlsUpdated();
 		});
-		this.iterateListeners((listener) => {
-			listener.offsetUpdated && listener.offsetUpdated(this,this.offsetX, this.offsetY)
+		this.iterateListeners(listener => {
+			listener.offsetUpdated &&
+				listener.offsetUpdated(this, this.offsetX, this.offsetY);
 		});
 	}
-	setOffsetY(offsetY: number){
+	setOffsetY(offsetY: number) {
 		this.offsetX = offsetY;
-		this.iterateListeners((listener) => {
-			if(listener.controlsUpdated) listener.controlsUpdated();
+		this.iterateListeners(listener => {
+			if (listener.controlsUpdated) listener.controlsUpdated();
 		});
-		this.iterateListeners((listener) => {
-			listener.offsetUpdated && listener.offsetUpdated(this,this.offsetX, this.offsetY)
+		this.iterateListeners(listener => {
+			listener.offsetUpdated &&
+				listener.offsetUpdated(this, this.offsetX, this.offsetY);
 		});
 	}
 
-	getOffsetY(){
+	getOffsetY() {
 		return this.offsetY;
 	}
 
-	getOffsetX(){
+	getOffsetX() {
 		return this.offsetX;
 	}
 
-	getZoomLevel(){
+	getZoomLevel() {
 		return this.zoom;
 	}
 
-	getNode(node: string | NodeModel): NodeModel|null{
-		if (node instanceof NodeModel){
+	getNode(node: string | NodeModel): NodeModel | null {
+		if (node instanceof NodeModel) {
 			return node;
 		}
-		if (!this.nodes[node]){
+		if (!this.nodes[node]) {
 			return null;
 		}
 		return this.nodes[node];
 	}
 
-	getLink(link: string | LinkModel): LinkModel|null{
-		if (link instanceof LinkModel){
+	getLink(link: string | LinkModel): LinkModel | null {
+		if (link instanceof LinkModel) {
 			return link;
 		}
-		if(!this.links[link]){
+		if (!this.links[link]) {
 			return null;
 		}
 		return this.links[link];
 	}
 
-	addLink(link: LinkModel): LinkModel{
+	addLink(link: LinkModel): LinkModel {
 		link.addListener({
 			entityRemoved: () => {
 				this.removeLink(link);
 			}
 		});
 		this.links[link.getID()] = link;
-		this.iterateListeners((listener) => {
-			if(listener.linksUpdated) listener.linksUpdated(link, true);
+		this.iterateListeners(listener => {
+			if (listener.linksUpdated) listener.linksUpdated(link, true);
 		});
-		return link
+		return link;
 	}
 
-	addNode(node: NodeModel): NodeModel{
+	addNode(node: NodeModel): NodeModel {
 		node.addListener({
 			entityRemoved: () => {
 				this.removeNode(node);
 			}
 		});
 		this.nodes[node.getID()] = node;
-		this.iterateListeners((listener) => {
-			if(listener.nodesUpdated) listener.nodesUpdated(node, true);
+		this.iterateListeners(listener => {
+			if (listener.nodesUpdated) listener.nodesUpdated(node, true);
 		});
 		return node;
 	}
 
-	removeLink(link: LinkModel | string){
-		if (link instanceof LinkModel){
+	removeLink(link: LinkModel | string) {
+		if (link instanceof LinkModel) {
 			delete this.links[link.getID()];
-			this.iterateListeners((listener) => {
-				if(listener.linksUpdated) listener.linksUpdated(link, false);
+			this.iterateListeners(listener => {
+				if (listener.linksUpdated) listener.linksUpdated(link, false);
 			});
 			return;
 		}
-		delete this.links[''+link];
-		this.iterateListeners((listener) => {
-			if(listener.linksUpdated) listener.linksUpdated(link, false);
+		delete this.links["" + link];
+		this.iterateListeners(listener => {
+			if (listener.linksUpdated) listener.linksUpdated(link, false);
 		});
 	}
-	removeNode(node: NodeModel | string){
-		if (node instanceof NodeModel){
+	removeNode(node: NodeModel | string) {
+		if (node instanceof NodeModel) {
 			delete this.nodes[node.getID()];
-			this.iterateListeners((listener) => {
-				if(listener.nodesUpdated) listener.nodesUpdated(node, false);
+			this.iterateListeners(listener => {
+				if (listener.nodesUpdated) listener.nodesUpdated(node, false);
 			});
 			return;
 		}
 
-		delete this.nodes[''+node];
-		this.iterateListeners((listener) => {
-			if(listener.nodesUpdated) listener.nodesUpdated(node, false);
+		delete this.nodes["" + node];
+		this.iterateListeners(listener => {
+			if (listener.nodesUpdated) listener.nodesUpdated(node, false);
 		});
 	}
 
-	getLinks():{[s:string] : LinkModel} {
+	getLinks(): { [s: string]: LinkModel } {
 		return this.links;
 	}
 
-	getNodes(): {[s: string]: NodeModel}{
+	getNodes(): { [s: string]: NodeModel } {
 		return this.nodes;
 	}
 }

--- a/src/Function.d.ts
+++ b/src/Function.d.ts
@@ -1,3 +1,3 @@
-interface Function{
-	name: string
+interface Function {
+	name: string;
 }

--- a/src/LinkInstanceFactory.ts
+++ b/src/LinkInstanceFactory.ts
@@ -1,16 +1,15 @@
-import {LinkModel} from "./Common";
+import { LinkModel } from "./Common";
 import * as _ from "lodash";
-import {AbstractInstanceFactory} from "./AbstractInstanceFactory";
+import { AbstractInstanceFactory } from "./AbstractInstanceFactory";
 /**
  * @author Dylan Vorster
  */
-export class LinkInstanceFactory extends AbstractInstanceFactory<LinkModel>{
-	
-	constructor(){
+export class LinkInstanceFactory extends AbstractInstanceFactory<LinkModel> {
+	constructor() {
 		super("LinkModel");
 	}
-	
-	getInstance(){
+
+	getInstance() {
 		return new LinkModel();
 	}
 }

--- a/src/Toolkit.ts
+++ b/src/Toolkit.ts
@@ -7,9 +7,10 @@ export class Toolkit {
    * Generats a unique ID (thanks Stack overflow :3)
    * @returns {String}
    */
-	public static UID():string {
-		return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-			var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+	public static UID(): string {
+		return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function(c) {
+			var r = (Math.random() * 16) | 0,
+				v = c == "x" ? r : (r & 0x3) | 0x8;
 			return v.toString(16);
 		});
 	}
@@ -20,10 +21,10 @@ export class Toolkit {
 	 * @param  {Element} element  [description]
 	 * @param  {string}  selector [description]
 	 */
-	public static closest(element: Element,selector:string){
-		if(document.body.closest){
+	public static closest(element: Element, selector: string) {
+		if (document.body.closest) {
 			return element.closest(selector);
 		}
-		return closest(element,selector);
+		return closest(element, selector);
 	}
 }

--- a/src/WidgetFactories.ts
+++ b/src/WidgetFactories.ts
@@ -1,31 +1,30 @@
-import {NodeModel, LinkModel} from "./Common";
-import {DiagramEngine} from "./DiagramEngine";
+import { NodeModel, LinkModel } from "./Common";
+import { DiagramEngine } from "./DiagramEngine";
 /**
  * @author Dylan Vorster
  */
-export abstract class WidgetFactory{
-	
+export abstract class WidgetFactory {
 	type: string;
-	
-	constructor(name: string){
+
+	constructor(name: string) {
 		this.type = name;
 	}
-	
-	getType(): string{
+
+	getType(): string {
 		return this.type;
 	}
-	
 }
 
-export abstract class NodeWidgetFactory extends WidgetFactory{
-	
-	
-	abstract generateReactWidget(diagramEngine:DiagramEngine,node: NodeModel): JSX.Element;
-	
+export abstract class NodeWidgetFactory extends WidgetFactory {
+	abstract generateReactWidget(
+		diagramEngine: DiagramEngine,
+		node: NodeModel
+	): JSX.Element;
 }
 
-export abstract class LinkWidgetFactory extends WidgetFactory{
-	
-	abstract generateReactWidget(diagramEngine:DiagramEngine,link: LinkModel): JSX.Element;
-	
+export abstract class LinkWidgetFactory extends WidgetFactory {
+	abstract generateReactWidget(
+		diagramEngine: DiagramEngine,
+		link: LinkModel
+	): JSX.Element;
 }

--- a/src/defaults/DefaultLinkFactory.ts
+++ b/src/defaults/DefaultLinkFactory.ts
@@ -1,22 +1,23 @@
-import {LinkWidgetFactory} from "../WidgetFactories";
-import {LinkModel} from "../Common";
+import { LinkWidgetFactory } from "../WidgetFactories";
+import { LinkModel } from "../Common";
 import * as React from "react";
-import {DefaultLinkWidget} from "./DefaultLinkWidget";
-import {DiagramEngine} from "../DiagramEngine";
+import { DefaultLinkWidget } from "./DefaultLinkWidget";
+import { DiagramEngine } from "../DiagramEngine";
 /**
  * @author Dylan Vorster
  */
-export class DefaultLinkFactory extends LinkWidgetFactory{
-	
-	constructor(){
+export class DefaultLinkFactory extends LinkWidgetFactory {
+	constructor() {
 		super("default");
 	}
-	
-	generateReactWidget(diagramEngine: DiagramEngine,link: LinkModel): JSX.Element{
-		return React.createElement(DefaultLinkWidget,{
+
+	generateReactWidget(
+		diagramEngine: DiagramEngine,
+		link: LinkModel
+	): JSX.Element {
+		return React.createElement(DefaultLinkWidget, {
 			link: link,
 			diagramEngine: diagramEngine
 		});
 	}
-	
 }

--- a/src/defaults/DefaultLinkWidget.tsx
+++ b/src/defaults/DefaultLinkWidget.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import {LinkModel, PointModel} from "../Common";
+import { LinkModel, PointModel } from "../Common";
 import * as _ from "lodash";
-import {DiagramEngine} from "../DiagramEngine";
+import { DiagramEngine } from "../DiagramEngine";
 
 export interface DefaultLinkProps {
 	color?: string;
@@ -9,7 +9,7 @@ export interface DefaultLinkProps {
 	link: LinkModel;
 	smooth?: boolean;
 	diagramEngine: DiagramEngine;
-	pointAdded?: (point: PointModel,event) => any
+	pointAdded?: (point: PointModel, event) => any;
 }
 
 export interface DefaultLinkState {
@@ -19,12 +19,14 @@ export interface DefaultLinkState {
 /**
  * @author Dylan Vorster
  */
-export class DefaultLinkWidget extends React.Component<DefaultLinkProps, DefaultLinkState> {
-
+export class DefaultLinkWidget extends React.Component<
+	DefaultLinkProps,
+	DefaultLinkState
+> {
 	public static defaultProps: DefaultLinkProps = {
-		color: 'black',
+		color: "black",
 		width: 3,
-		link:null,
+		link: null,
 		engine: null,
 		smooth: false,
 		diagramEngine: null
@@ -34,39 +36,53 @@ export class DefaultLinkWidget extends React.Component<DefaultLinkProps, Default
 		super(props);
 		this.state = {
 			selected: false
-		}
+		};
 	}
 
-	generatePoint(pointIndex: number): JSX.Element{
-
-		let x = this.props.diagramEngine.getDiagramModel().getGridPosition(this.props.link.points[pointIndex].x);
-		let y = this.props.diagramEngine.getDiagramModel().getGridPosition(this.props.link.points[pointIndex].y);
+	generatePoint(pointIndex: number): JSX.Element {
+		let x = this.props.diagramEngine
+			.getDiagramModel()
+			.getGridPosition(this.props.link.points[pointIndex].x);
+		let y = this.props.diagramEngine
+			.getDiagramModel()
+			.getGridPosition(this.props.link.points[pointIndex].y);
 
 		return (
-			<g key={'point-'+this.props.link.points[pointIndex].id}>
+			<g key={"point-" + this.props.link.points[pointIndex].id}>
 				<circle
-					cx={x} cy={y} r={5}
-					className={'point pointui' + (this.props.link.points[pointIndex].isSelected()?' selected':'')} />
+					cx={x}
+					cy={y}
+					r={5}
+					className={
+						"point pointui" +
+						(this.props.link.points[pointIndex].isSelected() ? " selected" : "")
+					}
+				/>
 				<circle
 					onMouseLeave={() => {
-						this.setState({selected: false});
+						this.setState({ selected: false });
 					}}
 					onMouseEnter={() => {
-						this.setState({selected: true});
+						this.setState({ selected: true });
 					}}
 					data-id={this.props.link.points[pointIndex].id}
 					data-linkid={this.props.link.id}
-					cx={x} cy={y} r={15}
+					cx={x}
+					cy={y}
+					r={15}
 					opacity={0}
-					className={'point'} />
+					className={"point"}
+				/>
 			</g>
 		);
 	}
 
-	generateLink(extraProps: any, id: string|number): JSX.Element{
+	generateLink(extraProps: any, id: string | number): JSX.Element {
 		var Bottom = (
 			<path
-				className={(this.state.selected || this.props.link.isSelected())?'selected':''}
+				className={
+					this.state.selected || this.props.link.isSelected() ? "selected" : ""
+				}
 				strokeWidth={this.props.width}
 				stroke={this.props.color}
 				{...extraProps}
@@ -77,17 +93,17 @@ export class DefaultLinkWidget extends React.Component<DefaultLinkProps, Default
 			<path
 				strokeLinecap="round"
 				onMouseLeave={() => {
-					this.setState({selected: false});
+					this.setState({ selected: false });
 				}}
 				onMouseEnter={() => {
-					this.setState({selected: true});
+					this.setState({ selected: true });
 				}}
 				data-linkid={this.props.link.getID()}
 				stroke={this.props.color}
-				strokeOpacity={this.state.selected?0.1:0}
+				strokeOpacity={this.state.selected ? 0.1 : 0}
 				strokeWidth={20}
-				onContextMenu={() =>{
-					if(!this.props.diagramEngine.isModelLocked(this.props.link)){
+				onContextMenu={() => {
+					if (!this.props.diagramEngine.isModelLocked(this.props.link)) {
 						event.preventDefault();
 						this.props.link.remove();
 					}
@@ -97,7 +113,10 @@ export class DefaultLinkWidget extends React.Component<DefaultLinkProps, Default
 		);
 
 		return (
-			<g key={'link-'+id}>{Bottom}{Top}</g>
+			<g key={"link-" + id}>
+				{Bottom}
+				{Top}
+			</g>
 		);
 	}
 
@@ -107,97 +126,194 @@ export class DefaultLinkWidget extends React.Component<DefaultLinkProps, Default
 		var paths = [];
 		let model = this.props.diagramEngine.getDiagramModel();
 
-        //draw the smoothing
-		if(points.length === 2){
-
-            //if the points are too close, just draw a straight line
+		//draw the smoothing
+		if (points.length === 2) {
+			//if the points are too close, just draw a straight line
 			var margin = 50;
-			if(Math.abs(points[0].x-points[1].x) < 50){
+			if (Math.abs(points[0].x - points[1].x) < 50) {
 				margin = 5;
 			}
 
-            var pointLeft = points[0];
-            var pointRight = points[1];
+			var pointLeft = points[0];
+			var pointRight = points[1];
 
-            //some defensive programming to make sure the smoothing is
-            //always in the right direction
-            if(pointLeft.x > pointRight.x){
-                pointLeft = points[1];
-                pointRight = points[0];
-            }
+			//some defensive programming to make sure the smoothing is
+			//always in the right direction
+			if (pointLeft.x > pointRight.x) {
+				pointLeft = points[1];
+				pointRight = points[0];
+			}
 
-			paths.push(this.generateLink({
-				onMouseDown: (event) =>{
-					if (!event.shiftKey && !this.props.diagramEngine.isModelLocked(this.props.link)){
-						var point = new PointModel(this.props.link,this.props.diagramEngine.getRelativeMousePoint(event));
-						point.setSelected(true);
-						this.forceUpdate();
-						this.props.link.addPoint(point,1);
-						this.props.pointAdded(point,event);
-					}
-				},
-				d:
-					 " M"+pointLeft.x+" "+pointLeft.y
-					+" C"+(pointLeft.x+margin)+" "+pointLeft.y
-					+" " +(pointRight.x-margin)+" "+pointRight.y
-					+" " +pointRight.x+" "+pointRight.y
-			},"0"));
-			if (this.props.link.targetPort === null){
+			paths.push(
+				this.generateLink(
+					{
+						onMouseDown: event => {
+							if (
+								!event.shiftKey &&
+								!this.props.diagramEngine.isModelLocked(this.props.link)
+							) {
+								var point = new PointModel(
+									this.props.link,
+									this.props.diagramEngine.getRelativeMousePoint(event)
+								);
+								point.setSelected(true);
+								this.forceUpdate();
+								this.props.link.addPoint(point, 1);
+								this.props.pointAdded(point, event);
+							}
+						},
+						d:
+							" M" +
+							pointLeft.x +
+							" " +
+							pointLeft.y +
+							" C" +
+							(pointLeft.x + margin) +
+							" " +
+							pointLeft.y +
+							" " +
+							(pointRight.x - margin) +
+							" " +
+							pointRight.y +
+							" " +
+							pointRight.x +
+							" " +
+							pointRight.y
+					},
+					"0"
+				)
+			);
+			if (this.props.link.targetPort === null) {
 				paths.push(this.generatePoint(1));
 			}
-		}
-
-        //draw the multiple anchors and complex line instead
-        else{
+		} else {
+			//draw the multiple anchors and complex line instead
 			var ds = [];
-			if(this.props.smooth){
-				ds.push(" M"+points[0].x+" "+points[0].y+" C "+(points[0].x+50)+" "+points[0].y+" "+points[1].x+" "+points[1].y+" "+points[1].x+" "+points[1].y);
-				for(var i = 1;i < points.length-2;i++){
-					ds.push(" M "+points[i].x+" "+points[i].y+" L "+points[i+1].x+" "+points[i+1].y);
+			if (this.props.smooth) {
+				ds.push(
+					" M" +
+						points[0].x +
+						" " +
+						points[0].y +
+						" C " +
+						(points[0].x + 50) +
+						" " +
+						points[0].y +
+						" " +
+						points[1].x +
+						" " +
+						points[1].y +
+						" " +
+						points[1].x +
+						" " +
+						points[1].y
+				);
+				for (var i = 1; i < points.length - 2; i++) {
+					ds.push(
+						" M " +
+							points[i].x +
+							" " +
+							points[i].y +
+							" L " +
+							points[i + 1].x +
+							" " +
+							points[i + 1].y
+					);
 				}
-				ds.push(" M"+points[i].x+" "+points[i].y+" C "+points[i].x+" "+points[i].y+" "+(points[i+1].x-50)+" "+points[i+1].y+" "+points[i+1].x+" "+points[i+1].y);
-			}else{
+				ds.push(
+					" M" +
+						points[i].x +
+						" " +
+						points[i].y +
+						" C " +
+						points[i].x +
+						" " +
+						points[i].y +
+						" " +
+						(points[i + 1].x - 50) +
+						" " +
+						points[i + 1].y +
+						" " +
+						points[i + 1].x +
+						" " +
+						points[i + 1].y
+				);
+			} else {
 				var ds = [];
-				for(var i = 0;i < points.length-1;i++){
-					if(i === 0){
-						ds.push(" M "+points[i].x+" "+points[i].y+" L "+model.getGridPosition(points[i+1].x)+" "+model.getGridPosition(points[i+1].y));
-					}else if(i === points.length-1){
-						ds.push(" M "+model.getGridPosition(points[i].x)+" "+model.getGridPosition(points[i].y)+" L "+model.getGridPosition(points[i+1].x)+" "+model.getGridPosition(points[i+1].y));
-					}else{
-						ds.push(" M "+model.getGridPosition(points[i].x)+" "+model.getGridPosition(points[i].y)+" L "+points[i+1].x+" "+points[i+1].y);
+				for (var i = 0; i < points.length - 1; i++) {
+					if (i === 0) {
+						ds.push(
+							" M " +
+								points[i].x +
+								" " +
+								points[i].y +
+								" L " +
+								model.getGridPosition(points[i + 1].x) +
+								" " +
+								model.getGridPosition(points[i + 1].y)
+						);
+					} else if (i === points.length - 1) {
+						ds.push(
+							" M " +
+								model.getGridPosition(points[i].x) +
+								" " +
+								model.getGridPosition(points[i].y) +
+								" L " +
+								model.getGridPosition(points[i + 1].x) +
+								" " +
+								model.getGridPosition(points[i + 1].y)
+						);
+					} else {
+						ds.push(
+							" M " +
+								model.getGridPosition(points[i].x) +
+								" " +
+								model.getGridPosition(points[i].y) +
+								" L " +
+								points[i + 1].x +
+								" " +
+								points[i + 1].y
+						);
 					}
 				}
 			}
 
-			paths = ds.map((data,index) => {
-				return this.generateLink({
-					'data-linkid':this.props.link.id,
-					'data-point':index,
-					onMouseDown: (event: MouseEvent) => {
-						if (!event.shiftKey && !this.props.diagramEngine.isModelLocked(this.props.link)){
-							var point = new PointModel(this.props.link,this.props.diagramEngine.getRelativeMousePoint(event));
-							point.setSelected(true);
-							this.forceUpdate();
-							this.props.link.addPoint(point,index+1);
-							this.props.pointAdded(point,event);
-						}
+			paths = ds.map((data, index) => {
+				return this.generateLink(
+					{
+						"data-linkid": this.props.link.id,
+						"data-point": index,
+						onMouseDown: (event: MouseEvent) => {
+							if (
+								!event.shiftKey &&
+								!this.props.diagramEngine.isModelLocked(this.props.link)
+							) {
+								var point = new PointModel(
+									this.props.link,
+									this.props.diagramEngine.getRelativeMousePoint(event)
+								);
+								point.setSelected(true);
+								this.forceUpdate();
+								this.props.link.addPoint(point, index + 1);
+								this.props.pointAdded(point, event);
+							}
+						},
+						d: data
 					},
-					d:data
-				},index);
+					index
+				);
 			});
 
 			//render the circles
-			for(var i = 1;i < points.length-1;i++){
+			for (var i = 1; i < points.length - 1; i++) {
 				paths.push(this.generatePoint(i));
 			}
 
-			if (this.props.link.targetPort === null){
-				paths.push(this.generatePoint(points.length-1));
+			if (this.props.link.targetPort === null) {
+				paths.push(this.generatePoint(points.length - 1));
 			}
 		}
 
-		return (
-			<g>{paths}</g>
-		);
+		return <g>{paths}</g>;
 	}
 }

--- a/src/defaults/DefaultNodeFactory.ts
+++ b/src/defaults/DefaultNodeFactory.ts
@@ -1,19 +1,21 @@
-import {NodeWidgetFactory} from "../WidgetFactories";
-import {DefaultNodeModel} from "./DefaultNodeModel";
+import { NodeWidgetFactory } from "../WidgetFactories";
+import { DefaultNodeModel } from "./DefaultNodeModel";
 import * as React from "react";
-import {DefaultNodeWidget} from "./DefaultNodeWidget";
-import {DiagramEngine} from "../DiagramEngine";
+import { DefaultNodeWidget } from "./DefaultNodeWidget";
+import { DiagramEngine } from "../DiagramEngine";
 /**
  * @author Dylan Vorster
  */
-export class DefaultNodeFactory extends NodeWidgetFactory{
-	
-	constructor(){
+export class DefaultNodeFactory extends NodeWidgetFactory {
+	constructor() {
 		super("default");
 	}
-	
-	generateReactWidget(diagramEngine:DiagramEngine,node: DefaultNodeModel): JSX.Element{
-		return React.createElement(DefaultNodeWidget,{
+
+	generateReactWidget(
+		diagramEngine: DiagramEngine,
+		node: DefaultNodeModel
+	): JSX.Element {
+		return React.createElement(DefaultNodeWidget, {
 			node: node,
 			diagramEngine: diagramEngine
 		});

--- a/src/defaults/DefaultNodeModel.ts
+++ b/src/defaults/DefaultNodeModel.ts
@@ -1,16 +1,17 @@
-import {NodeModel} from "../Common";
-import {DefaultPortModel} from "./DefaultPortModel";
+import { NodeModel } from "../Common";
+import { DefaultPortModel } from "./DefaultPortModel";
 import * as _ from "lodash";
 
-import {AbstractInstanceFactory} from "../AbstractInstanceFactory";
+import { AbstractInstanceFactory } from "../AbstractInstanceFactory";
 
-export class DefaultNodeInstanceFactory extends AbstractInstanceFactory<DefaultNodeModel>{
-	
-	constructor(){
+export class DefaultNodeInstanceFactory extends AbstractInstanceFactory<
+	DefaultNodeModel
+> {
+	constructor() {
 		super("DefaultNodeModel");
 	}
-	
-	getInstance(){
+
+	getInstance() {
 		return new DefaultNodeModel();
 	}
 }
@@ -18,39 +19,38 @@ export class DefaultNodeInstanceFactory extends AbstractInstanceFactory<DefaultN
 /**
  * @author Dylan Vorster
  */
-export class DefaultNodeModel extends NodeModel{
-	
+export class DefaultNodeModel extends NodeModel {
 	name: string;
 	color: string;
-	ports:  {[s: string]:DefaultPortModel};
-	
-	constructor(name: string = 'Untitled',color: string = 'rgb(0,192,255)'){
+	ports: { [s: string]: DefaultPortModel };
+
+	constructor(name: string = "Untitled", color: string = "rgb(0,192,255)") {
 		super("default");
 		this.name = name;
 		this.color = color;
 	}
-	
-	deSerialize(object){
+
+	deSerialize(object) {
 		super.deSerialize(object);
 		this.name = object.name;
 		this.color = object.color;
 	}
-	
-	serialize(){
-		return _.merge(super.serialize(),{
+
+	serialize() {
+		return _.merge(super.serialize(), {
 			name: this.name,
-			color: this.color,
+			color: this.color
 		});
 	}
-	
-	getInPorts(): DefaultPortModel[]{
-		return _.filter(this.ports,(portModel) => {
+
+	getInPorts(): DefaultPortModel[] {
+		return _.filter(this.ports, portModel => {
 			return portModel.in;
 		});
 	}
-	
-	getOutPorts(): DefaultPortModel[]{
-		return _.filter(this.ports,(portModel) => {
+
+	getOutPorts(): DefaultPortModel[] {
+		return _.filter(this.ports, portModel => {
 			return !portModel.in;
 		});
 	}

--- a/src/defaults/DefaultNodeWidget.tsx
+++ b/src/defaults/DefaultNodeWidget.tsx
@@ -1,50 +1,53 @@
 import * as React from "react";
 import * as _ from "lodash";
-import {DefaultNodeModel} from "./DefaultNodeModel";
-import {DefaultPortLabel} from "./DefaultPortLabelWidget";
-import {DiagramEngine} from "../DiagramEngine";
+import { DefaultNodeModel } from "./DefaultNodeModel";
+import { DefaultPortLabel } from "./DefaultPortLabelWidget";
+import { DiagramEngine } from "../DiagramEngine";
 
 export interface DefaultNodeProps {
 	node: DefaultNodeModel;
 	diagramEngine: DiagramEngine;
 }
 
-export interface DefaultNodeState {
-}
+export interface DefaultNodeState {}
 
 /**
  * @author Dylan Vorster
  */
-export class DefaultNodeWidget extends React.Component<DefaultNodeProps, DefaultNodeState> {
-
+export class DefaultNodeWidget extends React.Component<
+	DefaultNodeProps,
+	DefaultNodeState
+> {
 	constructor(props: DefaultNodeProps) {
 		super(props);
-		this.state = {
-		}
+		this.state = {};
 	}
 
-	generatePort(port){
-		return <DefaultPortLabel model={port} key={port.id} />
+	generatePort(port) {
+		return <DefaultPortLabel model={port} key={port.id} />;
 	}
 
 	render() {
 		return (
-			<div className="basic-node" style={{background: this.props.node.color}}>
+			<div className="basic-node" style={{ background: this.props.node.color }}>
 				<div className="title">
 					<div className="name">{this.props.node.name}</div>
-					<div className="fa fa-close" onClick={() => {
-						if(!this.props.diagramEngine.isModelLocked(this.props.node)){
-							this.props.node.remove();
-							this.props.diagramEngine.repaintCanvas();
-						}
-					}} />
+					<div
+						className="fa fa-close"
+						onClick={() => {
+							if (!this.props.diagramEngine.isModelLocked(this.props.node)) {
+								this.props.node.remove();
+								this.props.diagramEngine.repaintCanvas();
+							}
+						}}
+					/>
 				</div>
 				<div className="ports">
 					<div className="in">
-						{ _.map(this.props.node.getInPorts(),this.generatePort.bind(this)) }
+						{_.map(this.props.node.getInPorts(), this.generatePort.bind(this))}
 					</div>
 					<div className="out">
-						{ _.map(this.props.node.getOutPorts(),this.generatePort.bind(this)) }
+						{_.map(this.props.node.getOutPorts(), this.generatePort.bind(this))}
 					</div>
 				</div>
 			</div>

--- a/src/defaults/DefaultPortLabelWidget.tsx
+++ b/src/defaults/DefaultPortLabelWidget.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import {DefaultPortModel} from "./DefaultPortModel";
-import {PortWidget} from "../widgets/PortWidget";
+import { DefaultPortModel } from "./DefaultPortModel";
+import { PortWidget } from "../widgets/PortWidget";
 
 export interface DefaultPortLabelProps {
 	model?: DefaultPortModel;
@@ -8,27 +8,33 @@ export interface DefaultPortLabelProps {
 	label?: string;
 }
 
-export interface DefaultPortLabelState {
-}
+export interface DefaultPortLabelState {}
 
 /**
  * @author Dylan Vorster
  */
-export class DefaultPortLabel extends React.Component<DefaultPortLabelProps, DefaultPortLabelState> {
-
+export class DefaultPortLabel extends React.Component<
+	DefaultPortLabelProps,
+	DefaultPortLabelState
+> {
 	public static defaultProps: DefaultPortLabelProps = {
 		in: true,
 		label: "port"
 	};
 
 	render() {
-		var port = <PortWidget node={this.props.model.getParent()} name={this.props.model.name} />
-		var label = <div className="name">{this.props.model.label}</div>
+		var port = (
+			<PortWidget
+				node={this.props.model.getParent()}
+				name={this.props.model.name}
+			/>
+		);
+		var label = <div className="name">{this.props.model.label}</div>;
 
 		return (
-			<div className={(this.props.model.in?'in':'out') + '-port'}>
-				{ this.props.model.in?port:label }
-				{ this.props.model.in?label:port }
+			<div className={(this.props.model.in ? "in" : "out") + "-port"}>
+				{this.props.model.in ? port : label}
+				{this.props.model.in ? label : port}
 			</div>
 		);
 	}

--- a/src/defaults/DefaultPortModel.ts
+++ b/src/defaults/DefaultPortModel.ts
@@ -1,41 +1,47 @@
-import {PortModel} from "../Common";
+import { PortModel } from "../Common";
 import * as _ from "lodash";
-import {AbstractInstanceFactory} from "../AbstractInstanceFactory";
+import { AbstractInstanceFactory } from "../AbstractInstanceFactory";
 
-export class DefaultPortInstanceFactory extends AbstractInstanceFactory<DefaultPortModel>{
-	
-	constructor(){
+export class DefaultPortInstanceFactory extends AbstractInstanceFactory<
+	DefaultPortModel
+> {
+	constructor() {
 		super("DefaultPortModel");
 	}
-	
-	getInstance(){
-		return new DefaultPortModel(true,"unknown");
+
+	getInstance() {
+		return new DefaultPortModel(true, "unknown");
 	}
 }
 
 /**
  * @author Dylan Vorster
  */
-export class DefaultPortModel extends PortModel{
+export class DefaultPortModel extends PortModel {
 	in: boolean;
 	label: string;
-	
-	constructor(isInput:boolean,name: string,label: string = null, id?: string){
+
+	constructor(
+		isInput: boolean,
+		name: string,
+		label: string = null,
+		id?: string
+	) {
 		super(name, id);
 		this.in = isInput;
 		this.label = label || name;
 	}
-	
-	deSerialize(object){
+
+	deSerialize(object) {
 		super.deSerialize(object);
 		this.in = object.in;
 		this.label = object.label;
 	}
-	
-	serialize(){
-		return _.merge(super.serialize(),{
+
+	serialize() {
+		return _.merge(super.serialize(), {
 			in: this.in,
-			label: this.label,
+			label: this.label
 		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 /**
  * @author Dylan Vorster
  */
- 
- //export defaults
+
+//export defaults
 export * from "./defaults/DefaultLinkFactory";
 export * from "./defaults/DefaultLinkWidget";
 export * from "./defaults/DefaultNodeFactory";

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -1,11 +1,23 @@
 import * as React from "react";
-import {DiagramEngine} from "../DiagramEngine";
+import { DiagramEngine } from "../DiagramEngine";
 import * as _ from "lodash";
-import {PointModel, NodeModel, BaseModel, BaseModelListener, LinkModel, PortModel} from "../Common";
-import {LinkLayerWidget} from "./LinkLayerWidget";
-import {NodeLayerWidget} from "./NodeLayerWidget";
-import {Toolkit} from "../Toolkit";
-import {BaseAction, MoveCanvasAction, MoveItemsAction, SelectingAction} from "../CanvasActions";
+import {
+	PointModel,
+	NodeModel,
+	BaseModel,
+	BaseModelListener,
+	LinkModel,
+	PortModel
+} from "../Common";
+import { LinkLayerWidget } from "./LinkLayerWidget";
+import { NodeLayerWidget } from "./NodeLayerWidget";
+import { Toolkit } from "../Toolkit";
+import {
+	BaseAction,
+	MoveCanvasAction,
+	MoveItemsAction,
+	SelectingAction
+} from "../CanvasActions";
 
 export interface SelectionModel {
 	model: BaseModel<BaseModelListener>;
@@ -29,18 +41,17 @@ export interface DiagramProps {
 
 export interface DiagramState {
 	action: BaseAction | null;
-	wasMoved: boolean,
-	renderedNodes: boolean,
-	windowListener: any,
-	diagramEngineListener: any,
-	document: any
+	wasMoved: boolean;
+	renderedNodes: boolean;
+	windowListener: any;
+	diagramEngineListener: any;
+	document: any;
 }
 
 /**
  * @author Dylan Vorster
  */
 export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
-
 	public static defaultProps: DiagramProps = {
 		diagramEngine: null,
 		allowLooseLinks: true,
@@ -60,7 +71,7 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 			windowListener: null,
 			diagramEngineListener: null,
 			document: null
-		}
+		};
 	}
 
 	onKeyUpPointer: null;
@@ -68,18 +79,21 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 	componentWillUnmount() {
 		this.props.diagramEngine.removeListener(this.state.diagramEngineListener);
 		this.props.diagramEngine.setCanvas(null);
-		window.removeEventListener('keyup', this.onKeyUpPointer);
-		window.removeEventListener('mouseUp', this.onMouseUp);
-		window.removeEventListener('mouseMove', this.onMouseMove);
+		window.removeEventListener("keyup", this.onKeyUpPointer);
+		window.removeEventListener("mouseUp", this.onMouseUp);
+		window.removeEventListener("mouseMove", this.onMouseMove);
 	}
 
 	componentWillUpdate(nextProps: DiagramProps) {
-		if (this.props.diagramEngine.diagramModel.id !== nextProps.diagramEngine.diagramModel.id) {
-			this.setState({renderedNodes: false});
+		if (
+			this.props.diagramEngine.diagramModel.id !==
+			nextProps.diagramEngine.diagramModel.id
+		) {
+			this.setState({ renderedNodes: false });
 			nextProps.diagramEngine.diagramModel.rendered = true;
 		}
 		if (!nextProps.diagramEngine.diagramModel.rendered) {
-			this.setState({renderedNodes: false});
+			this.setState({ renderedNodes: false });
 			nextProps.diagramEngine.diagramModel.rendered = true;
 		}
 	}
@@ -93,7 +107,6 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 	}
 
 	componentDidMount() {
-
 		this.onKeyUpPointer = this.onKeyUp.bind(this);
 
 		//add a keyboard listener
@@ -104,10 +117,10 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 				repaintCanvas: () => {
 					this.forceUpdate();
 				}
-			}),
+			})
 		});
 
-		window.addEventListener('keyup', this.onKeyUpPointer, false);
+		window.addEventListener("keyup", this.onKeyUpPointer, false);
 
 		window.focus();
 	}
@@ -115,45 +128,54 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 	/**
 	 * Gets a model and element under the mouse cursor
 	 */
-	getMouseElement(event): { model: BaseModel<BaseModelListener>, element: Element } {
+	getMouseElement(
+		event
+	): { model: BaseModel<BaseModelListener>; element: Element } {
 		var target = event.target as Element;
 		var diagramModel = this.props.diagramEngine.diagramModel;
 
 		//is it a port
-		var element = Toolkit.closest(target, '.port[data-name]');
+		var element = Toolkit.closest(target, ".port[data-name]");
 		if (element) {
-			var nodeElement = Toolkit.closest(target, '.node[data-nodeid]') as HTMLElement;
+			var nodeElement = Toolkit.closest(
+				target,
+				".node[data-nodeid]"
+			) as HTMLElement;
 			return {
-				model: diagramModel.getNode(nodeElement.getAttribute('data-nodeid')).getPort(element.getAttribute('data-name')),
+				model: diagramModel
+					.getNode(nodeElement.getAttribute("data-nodeid"))
+					.getPort(element.getAttribute("data-name")),
 				element: element
 			};
 		}
 
 		//look for a point
-		element = Toolkit.closest(target, '.point[data-id]');
+		element = Toolkit.closest(target, ".point[data-id]");
 		if (element) {
 			return {
-				model: diagramModel.getLink(element.getAttribute('data-linkid')).getPointModel(element.getAttribute('data-id')),
+				model: diagramModel
+					.getLink(element.getAttribute("data-linkid"))
+					.getPointModel(element.getAttribute("data-id")),
 				element: element
 			};
 		}
 
 		//look for a link
-		element = Toolkit.closest(target, '[data-linkid]');
+		element = Toolkit.closest(target, "[data-linkid]");
 		if (element) {
 			return {
-				model: diagramModel.getLink(element.getAttribute('data-linkid')),
+				model: diagramModel.getLink(element.getAttribute("data-linkid")),
 				element: element
 			};
 		}
 
 		//look for a node
-		element = Toolkit.closest(target, '.node[data-nodeid]');
+		element = Toolkit.closest(target, ".node[data-nodeid]");
 		if (element) {
 			return {
-				model: diagramModel.getNode(element.getAttribute('data-nodeid')),
+				model: diagramModel.getNode(element.getAttribute("data-nodeid")),
 				element: element
-			}
+			};
 		}
 
 		return null;
@@ -169,7 +191,7 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 		if (this.props.actionStoppedFiring && !shouldSkipEvent) {
 			this.props.actionStoppedFiring(this.state.action);
 		}
-		this.setState({action: null});
+		this.setState({ action: null });
 	}
 
 	startFiringAction(action: BaseAction) {
@@ -178,7 +200,7 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 			setState = this.props.actionStartedFiring(action);
 		}
 		if (setState) {
-			this.setState({action: action});
+			this.setState({ action: action });
 		}
 	}
 
@@ -187,18 +209,33 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 		var diagramModel = diagramEngine.getDiagramModel();
 		//select items so draw a bounding box
 		if (this.state.action instanceof SelectingAction) {
-			var relative = diagramEngine.getRelativePoint(event.clientX, event.clientY);
+			var relative = diagramEngine.getRelativePoint(
+				event.clientX,
+				event.clientY
+			);
 
-			_.forEach(diagramModel.getNodes(), (node) => {
-				if ((this.state.action as SelectingAction).containsElement(node.x, node.y, diagramModel)) {
+			_.forEach(diagramModel.getNodes(), node => {
+				if (
+					(this.state.action as SelectingAction).containsElement(
+						node.x,
+						node.y,
+						diagramModel
+					)
+				) {
 					node.setSelected(true);
 				}
 			});
 
-			_.forEach(diagramModel.getLinks(), (link) => {
+			_.forEach(diagramModel.getLinks(), link => {
 				var allSelected = true;
-				_.forEach(link.points, (point) => {
-					if ((this.state.action as SelectingAction).containsElement(point.x, point.y, diagramModel)) {
+				_.forEach(link.points, point => {
+					if (
+						(this.state.action as SelectingAction).containsElement(
+							point.x,
+							point.y,
+							diagramModel
+						)
+					) {
 						point.setSelected(true);
 					} else {
 						allSelected = false;
@@ -208,37 +245,48 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 				if (allSelected) {
 					link.setSelected(true);
 				}
-			})
+			});
 
 			this.state.action.mouseX2 = relative.x;
 			this.state.action.mouseY2 = relative.y;
 
 			this.fireAction();
-			this.setState({action: this.state.action});
+			this.setState({ action: this.state.action });
 			return;
-		}
-
-		//translate the items on the canvas
-		else if (this.state.action instanceof MoveItemsAction) {
+		} else if (this.state.action instanceof MoveItemsAction) {
+			//translate the items on the canvas
 			if (!this.state.wasMoved) {
-				this.setState({...this.state, wasMoved: true});
+				this.setState({ ...this.state, wasMoved: true });
 			}
-			_.forEach(this.state.action.selectionModels, (model) => {
-				if (model.model instanceof NodeModel || model.model instanceof PointModel) {
-					model.model.x = diagramModel.getGridPosition(model.initialX + ((event.clientX - this.state.action.mouseX) / (diagramModel.getZoomLevel() / 100)));
-					model.model.y = diagramModel.getGridPosition(model.initialY + ((event.clientY - this.state.action.mouseY) / (diagramModel.getZoomLevel() / 100)));
+			_.forEach(this.state.action.selectionModels, model => {
+				if (
+					model.model instanceof NodeModel ||
+					model.model instanceof PointModel
+				) {
+					model.model.x = diagramModel.getGridPosition(
+						model.initialX +
+							(event.clientX - this.state.action.mouseX) /
+								(diagramModel.getZoomLevel() / 100)
+					);
+					model.model.y = diagramModel.getGridPosition(
+						model.initialY +
+							(event.clientY - this.state.action.mouseY) /
+								(diagramModel.getZoomLevel() / 100)
+					);
 				}
 			});
 			this.fireAction();
 			this.forceUpdate();
-		}
-
-		//translate the actual canvas
-		else if (this.state.action instanceof MoveCanvasAction) {
+		} else if (this.state.action instanceof MoveCanvasAction) {
+			//translate the actual canvas
 			if (this.props.allowCanvasTranslation) {
 				diagramModel.setOffset(
-					this.state.action.initialOffsetX + ((event.clientX - this.state.action.mouseX) / (diagramModel.getZoomLevel() / 100)),
-					this.state.action.initialOffsetY + ((event.clientY - this.state.action.mouseY) / (diagramModel.getZoomLevel() / 100))
+					this.state.action.initialOffsetX +
+						(event.clientX - this.state.action.mouseX) /
+							(diagramModel.getZoomLevel() / 100),
+					this.state.action.initialOffsetY +
+						(event.clientY - this.state.action.mouseY) /
+							(diagramModel.getZoomLevel() / 100)
 				);
 				this.fireAction();
 				this.forceUpdate();
@@ -246,17 +294,18 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 		}
 	}
 
-	onKeyUp(event){
-
+	onKeyUp(event) {
 		//delete all selected
 		if (this.props.deleteKeys.indexOf(event.keyCode) !== -1) {
-			_.forEach(this.props.diagramEngine.getDiagramModel().getSelectedItems(), (element) => {
-
-				//only delete items which are not locked
-				if (!this.props.diagramEngine.isModelLocked(element)) {
-					element.remove();
+			_.forEach(
+				this.props.diagramEngine.getDiagramModel().getSelectedItems(),
+				element => {
+					//only delete items which are not locked
+					if (!this.props.diagramEngine.isModelLocked(element)) {
+						element.remove();
+					}
 				}
-			});
+			);
 			this.forceUpdate();
 		}
 	}
@@ -267,14 +316,17 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 		if (this.state.action instanceof MoveItemsAction) {
 			var element = this.getMouseElement(event);
 			var linkConnected = false;
-			_.forEach(this.state.action.selectionModels, (model) => {
-
+			_.forEach(this.state.action.selectionModels, model => {
 				//only care about points connecting to things
 				if (!(model.model instanceof PointModel)) {
 					return;
 				}
 
-				if (element && element.model instanceof PortModel && !diagramEngine.isModelLocked(element.model)) {
+				if (
+					element &&
+					element.model instanceof PortModel &&
+					!diagramEngine.isModelLocked(element.model)
+				) {
 					linkConnected = true;
 					let link = model.model.getLink();
 					link.setTargetPort(element.model);
@@ -283,8 +335,7 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 
 			//do we want to allow loose links on the diagram model or not
 			if (!linkConnected && !this.props.allowLooseLinks) {
-				_.forEach(this.state.action.selectionModels, (model) => {
-
+				_.forEach(this.state.action.selectionModels, model => {
 					//only care about points connecting to things
 					if (!(model.model instanceof PointModel)) {
 						return;
@@ -298,17 +349,16 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 			}
 			diagramEngine.clearRepaintEntities();
 			this.stopFiringAction(!this.state.wasMoved);
-
 		} else {
 			diagramEngine.clearRepaintEntities();
 			this.stopFiringAction();
 		}
 
-		this.state.document.removeEventListener('mousemove', this.onMouseMove);
-		this.state.document.removeEventListener('mouseup', this.onMouseUp);
+		this.state.document.removeEventListener("mousemove", this.onMouseMove);
+		this.state.document.removeEventListener("mouseup", this.onMouseUp);
 	}
 
-	drawSelectionBox(){
+	drawSelectionBox() {
 		let dimensions = (this.state.action as SelectingAction).getBoxDimensions();
 		return (
 			<div
@@ -317,7 +367,7 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 					top: dimensions.top,
 					left: dimensions.left,
 					width: dimensions.width,
-					height: dimensions.height,
+					height: dimensions.height
 				}}
 			/>
 		);
@@ -329,26 +379,28 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 
 		return (
 			<div
-				ref={(ref) => {
-					if(ref){
+				ref={ref => {
+					if (ref) {
 						this.props.diagramEngine.setCanvas(ref);
 					}
 				}}
 				className="storm-diagrams-canvas"
-				onWheel={(event) => {
+				onWheel={event => {
 					if (this.props.allowCanvasZoom) {
 						event.preventDefault();
 						event.stopPropagation();
-						diagramModel.setZoomLevel(diagramModel.getZoomLevel() + (event.deltaY / 60));
+						diagramModel.setZoomLevel(
+							diagramModel.getZoomLevel() + event.deltaY / 60
+						);
 						diagramEngine.enableRepaintEntities([]);
 						this.forceUpdate();
 						setTimeout(() => {
 							this.forceUpdate();
-						}, 100)
+						}, 100);
 					}
 				}}
-				onMouseDown={(event) => {
-					this.setState({...this.state, wasMoved: false});
+				onMouseDown={event => {
+					this.setState({ ...this.state, wasMoved: false });
 
 					diagramEngine.clearRepaintEntities();
 					var model = this.getMouseElement(event);
@@ -356,68 +408,79 @@ export class DiagramWidget extends React.Component<DiagramProps, DiagramState> {
 					if (model === null) {
 						//is it a multiple selection
 						if (event.shiftKey) {
-							var relative = diagramEngine.getRelativePoint(event.clientX, event.clientY);
-							this.startFiringAction(new SelectingAction(relative.x, relative.y));
-						}
-
-						//its a drag the canvas event
-						else {
+							var relative = diagramEngine.getRelativePoint(
+								event.clientX,
+								event.clientY
+							);
+							this.startFiringAction(
+								new SelectingAction(relative.x, relative.y)
+							);
+						} else {
+							//its a drag the canvas event
 							diagramModel.clearSelection();
-							this.startFiringAction(new MoveCanvasAction(event.clientX, event.clientY, diagramModel));
+							this.startFiringAction(
+								new MoveCanvasAction(event.clientX, event.clientY, diagramModel)
+							);
 						}
-					}
-
-					//its a port element, we want to drag a link
-					else if (model.model instanceof PortModel) {
-						if(!this.props.diagramEngine.isModelLocked(model.model)) {
-
+					} else if (model.model instanceof PortModel) {
+						//its a port element, we want to drag a link
+						if (!this.props.diagramEngine.isModelLocked(model.model)) {
 							var relative = diagramEngine.getRelativeMousePoint(event);
 							var link = new LinkModel();
 							link.setSourcePort(model.model);
 
-							link.getFirstPoint().updateLocation(relative)
+							link.getFirstPoint().updateLocation(relative);
 							link.getLastPoint().updateLocation(relative);
 
 							diagramModel.clearSelection();
 							link.getLastPoint().setSelected(true);
 							diagramModel.addLink(link);
 
-							this.startFiringAction(new MoveItemsAction(event.clientX, event.clientY, diagramEngine));
-						}else{
+							this.startFiringAction(
+								new MoveItemsAction(event.clientX, event.clientY, diagramEngine)
+							);
+						} else {
 							diagramModel.clearSelection();
 						}
-					}
-					//its some or other element, probably want to move it
-					else {
+					} else {
+						//its some or other element, probably want to move it
 						if (!event.shiftKey && !model.model.isSelected()) {
 							diagramModel.clearSelection();
 						}
 						model.model.setSelected(true);
 
-						this.startFiringAction(new MoveItemsAction(event.clientX, event.clientY, diagramEngine));
+						this.startFiringAction(
+							new MoveItemsAction(event.clientX, event.clientY, diagramEngine)
+						);
 					}
-					this.state.document.addEventListener('mousemove', this.onMouseMove);
-					this.state.document.addEventListener('mouseup', this.onMouseUp);
+					this.state.document.addEventListener("mousemove", this.onMouseMove);
+					this.state.document.addEventListener("mouseup", this.onMouseUp);
 				}}
 			>
-				{
-					this.state.renderedNodes &&
-						<LinkLayerWidget diagramEngine={diagramEngine} pointAdded={(point: PointModel, event) => {
-							this.state.document.addEventListener('mousemove', this.onMouseMove);
-							this.state.document.addEventListener('mouseup', this.onMouseUp);
+				{this.state.renderedNodes && (
+					<LinkLayerWidget
+						diagramEngine={diagramEngine}
+						pointAdded={(point: PointModel, event) => {
+							this.state.document.addEventListener(
+								"mousemove",
+								this.onMouseMove
+							);
+							this.state.document.addEventListener("mouseup", this.onMouseUp);
 							event.stopPropagation();
 							diagramModel.clearSelection(point);
 							this.setState({
-								action: new MoveItemsAction(event.clientX, event.clientY, diagramEngine)
+								action: new MoveItemsAction(
+									event.clientX,
+									event.clientY,
+									diagramEngine
+								)
 							});
 						}}
 					/>
-				}
+				)}
 				<NodeLayerWidget diagramEngine={diagramEngine} />
-				{
-					this.state.action instanceof SelectingAction &&
-						this.drawSelectionBox()
-				}
+				{this.state.action instanceof SelectingAction &&
+					this.drawSelectionBox()}
 			</div>
 		);
 	}

--- a/src/widgets/LinkLayerWidget.tsx
+++ b/src/widgets/LinkLayerWidget.tsx
@@ -1,73 +1,87 @@
 import * as React from "react";
-import {DiagramModel} from "../DiagramModel";
-import {DiagramEngine} from "../DiagramEngine";
-import {PointModel} from "../Common";
-import {LinkWidget} from "./LinkWidget";
+import { DiagramModel } from "../DiagramModel";
+import { DiagramEngine } from "../DiagramEngine";
+import { PointModel } from "../Common";
+import { LinkWidget } from "./LinkWidget";
 import * as _ from "lodash";
 
 export interface LinkLayerProps {
-	diagramEngine: DiagramEngine,
-	pointAdded: (point: PointModel,event) => any
+	diagramEngine: DiagramEngine;
+	pointAdded: (point: PointModel, event) => any;
 }
 
-export interface LinkLayerState {
-}
+export interface LinkLayerState {}
 
 /**
  * @author Dylan Vorster
  */
-export class LinkLayerWidget extends React.Component<LinkLayerProps, LinkLayerState> {
-
+export class LinkLayerWidget extends React.Component<
+	LinkLayerProps,
+	LinkLayerState
+> {
 	constructor(props: LinkLayerProps) {
 		super(props);
-		this.state = {
-		}
+		this.state = {};
 	}
 
 	render() {
 		var diagramModel = this.props.diagramEngine.getDiagramModel();
 		return (
-			<svg style={{
-				transform: 'scale(' + diagramModel.getZoomLevel() / 100.0 + ') translate(' + diagramModel.getOffsetX() + 'px,' + diagramModel.getOffsetY()+'px)',
-				width: '100%',
-				height: '100%'
-			}}>
-				{
-					//only perform these actions when we have a diagram
-					this.props.diagramEngine.canvas &&
-						_.map(diagramModel.getLinks(),(link) => {
+			<svg
+				style={{
+					transform:
+						"scale(" +
+						diagramModel.getZoomLevel() / 100.0 +
+						") translate(" +
+						diagramModel.getOffsetX() +
+						"px," +
+						diagramModel.getOffsetY() +
+						"px)",
+					width: "100%",
+					height: "100%"
+				}}
+			>
+				{//only perform these actions when we have a diagram
+				this.props.diagramEngine.canvas &&
+					_.map(diagramModel.getLinks(), link => {
+						//TODO just improve this vastly x_x
+						if (link.sourcePort !== null) {
+							//generate a point
+							try {
+								link.points[0].updateLocation(
+									this.props.diagramEngine.getPortCenter(link.sourcePort)
+								);
+							} catch (ex) {}
+						}
+						if (link.targetPort !== null) {
+							try {
+								_.last(link.points).updateLocation(
+									this.props.diagramEngine.getPortCenter(link.targetPort)
+								);
+							} catch (ex) {}
+						}
 
-							//TODO just improve this vastly x_x
-							if (link.sourcePort !== null){
-								//generate a point
-								try {
-									link.points[0].updateLocation(this.props.diagramEngine.getPortCenter(link.sourcePort));
-								} catch(ex){
+						//generate links
+						var generatedLink = this.props.diagramEngine.generateWidgetForLink(
+							link
+						);
+						if (!generatedLink) {
+							console.log("no link generated for type: " + link.getType());
+							return null;
+						}
 
-								}
-							}
-							if (link.targetPort !== null){
-								try{
-									_.last(link.points).updateLocation(this.props.diagramEngine.getPortCenter(link.targetPort));
-								} catch(ex){
-
-								}
-							}
-
-							//generate links
-							var generatedLink = this.props.diagramEngine.generateWidgetForLink(link);
-							if(!generatedLink){
-								console.log("no link generated for type: " + link.getType());
-								return null;
-							}
-
-							return (
-								<LinkWidget key={link.getID()} link={link} diagramEngine={this.props.diagramEngine} >
-									{React.cloneElement(generatedLink,{pointAdded: this.props.pointAdded})}
-								</LinkWidget>
-							);
-						})
-				}
+						return (
+							<LinkWidget
+								key={link.getID()}
+								link={link}
+								diagramEngine={this.props.diagramEngine}
+							>
+								{React.cloneElement(generatedLink, {
+									pointAdded: this.props.pointAdded
+								})}
+							</LinkWidget>
+						);
+					})}
 			</svg>
 		);
 	}

--- a/src/widgets/LinkWidget.tsx
+++ b/src/widgets/LinkWidget.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import {LinkModel} from "../Common";
-import {DiagramEngine} from "../DiagramEngine";
+import { LinkModel } from "../Common";
+import { DiagramEngine } from "../DiagramEngine";
 
 export interface LinkProps {
 	link: LinkModel;
@@ -8,21 +8,18 @@ export interface LinkProps {
 	children?: any;
 }
 
-export interface LinkState {
-}
+export interface LinkState {}
 
 /**
  * @author Dylan Vorster
  */
 export class LinkWidget extends React.Component<LinkProps, LinkState> {
-
 	constructor(props: LinkProps) {
 		super(props);
-		this.state = {
-		}
+		this.state = {};
 	}
-	
-	shouldComponentUpdate(){
+
+	shouldComponentUpdate() {
 		return this.props.diagramEngine.canEntityRepaint(this.props.link);
 	}
 

--- a/src/widgets/NodeLayerWidget.tsx
+++ b/src/widgets/NodeLayerWidget.tsx
@@ -1,48 +1,57 @@
 import * as React from "react";
-import {DiagramModel} from "../DiagramModel";
-import {DiagramEngine} from "../DiagramEngine";
+import { DiagramModel } from "../DiagramModel";
+import { DiagramEngine } from "../DiagramEngine";
 import * as _ from "lodash";
-import {NodeWidget} from "./NodeWidget";
+import { NodeWidget } from "./NodeWidget";
 
 export interface NodeLayerProps {
-	diagramEngine: DiagramEngine
+	diagramEngine: DiagramEngine;
 }
 
-export interface NodeLayerState {
-}
+export interface NodeLayerState {}
 
 /**
  * @author Dylan Vorster
  */
-export class NodeLayerWidget extends React.Component<NodeLayerProps, NodeLayerState> {
-
+export class NodeLayerWidget extends React.Component<
+	NodeLayerProps,
+	NodeLayerState
+> {
 	constructor(props: NodeLayerProps) {
 		super(props);
-		this.state = {
-		}
+		this.state = {};
 	}
 
 	render() {
-
 		var diagramModel = this.props.diagramEngine.getDiagramModel();
 
 		return (
 			<div
 				className="node-view"
 				style={{
-					transform: 'scale(' + diagramModel.getZoomLevel() / 100.0 + ') translate(' + diagramModel.getOffsetX()+'px,'+diagramModel.getOffsetY()+'px)',
-					width: '100%',
-					height: '100%'
+					transform:
+						"scale(" +
+						diagramModel.getZoomLevel() / 100.0 +
+						") translate(" +
+						diagramModel.getOffsetX() +
+						"px," +
+						diagramModel.getOffsetY() +
+						"px)",
+					width: "100%",
+					height: "100%"
 				}}
 			>
-				{
-					_.map(diagramModel.getNodes(),(node) => {
-						return(
-							React.createElement(NodeWidget, {diagramEngine: this.props.diagramEngine,key:node.id,node: node},
-								this.props.diagramEngine.generateWidgetForNode(node))
-						);
-					})
-				}
+				{_.map(diagramModel.getNodes(), node => {
+					return React.createElement(
+						NodeWidget,
+						{
+							diagramEngine: this.props.diagramEngine,
+							key: node.id,
+							node: node
+						},
+						this.props.diagramEngine.generateWidgetForNode(node)
+					);
+				})}
 			</div>
 		);
 	}

--- a/src/widgets/NodeWidget.tsx
+++ b/src/widgets/NodeWidget.tsx
@@ -1,28 +1,25 @@
 import * as React from "react";
-import {NodeModel} from "../Common";
-import {DiagramEngine} from "../DiagramEngine";
+import { NodeModel } from "../Common";
+import { DiagramEngine } from "../DiagramEngine";
 
 export interface NodeProps {
-	node:NodeModel;
+	node: NodeModel;
 	children?: any;
-	diagramEngine: DiagramEngine
+	diagramEngine: DiagramEngine;
 }
 
-export interface NodeState {
-}
+export interface NodeState {}
 
 /**
  * @author Dylan Vorster
  */
 export class NodeWidget extends React.Component<NodeProps, NodeState> {
-
 	constructor(props: NodeProps) {
 		super(props);
-		this.state = {
-		}
+		this.state = {};
 	}
 
-	shouldComponentUpdate(){
+	shouldComponentUpdate() {
 		return this.props.diagramEngine.canEntityRepaint(this.props.node);
 	}
 
@@ -30,13 +27,17 @@ export class NodeWidget extends React.Component<NodeProps, NodeState> {
 		return (
 			<div
 				data-nodeid={this.props.node.id}
-				className={'node' + (this.props.node.isSelected()?' selected':'')}
+				className={"node" + (this.props.node.isSelected() ? " selected" : "")}
 				style={{
-					top: this.props.diagramEngine.getDiagramModel().getGridPosition(this.props.node.y),
-					left: this.props.diagramEngine.getDiagramModel().getGridPosition(this.props.node.x),
+					top: this.props.diagramEngine
+						.getDiagramModel()
+						.getGridPosition(this.props.node.y),
+					left: this.props.diagramEngine
+						.getDiagramModel()
+						.getGridPosition(this.props.node.x)
 				}}
 			>
-				{React.cloneElement(this.props.children,{})}
+				{React.cloneElement(this.props.children, {})}
 			</div>
 		);
 	}

--- a/src/widgets/PortWidget.tsx
+++ b/src/widgets/PortWidget.tsx
@@ -1,21 +1,20 @@
 import * as React from "react";
-import {NodeModel} from "../Common";
+import { NodeModel } from "../Common";
 
 export interface PortProps {
 	name: string;
 	node: NodeModel;
 }
 
-export interface PortState{
-	selected: boolean
+export interface PortState {
+	selected: boolean;
 }
 
 /**
  * @author Dylan Vorster
  */
 export class PortWidget extends React.Component<PortProps, PortState> {
-
-	constructor(props: PortProps){
+	constructor(props: PortProps) {
 		super(props);
 		this.state = {
 			selected: false
@@ -25,15 +24,13 @@ export class PortWidget extends React.Component<PortProps, PortState> {
 	render() {
 		return (
 			<div
-				onMouseEnter={() =>{
-					this.setState({selected: true});
+				onMouseEnter={() => {
+					this.setState({ selected: true });
 				}}
-
 				onMouseLeave={() => {
-					this.setState({selected: false});
+					this.setState({ selected: false });
 				}}
-
-				className={'port'+(this.state.selected?' selected':'')}
+				className={"port" + (this.state.selected ? " selected" : "")}
 				data-name={this.props.name}
 				data-nodeid={this.props.node.getID()}
 			/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4610,6 +4610,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.6.1.tgz#850f411a3116226193e32ea5acfc21c0f9a76d7d"
+
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"


### PR DESCRIPTION
It's hard to keep track of the space after a comma, those semicolons and quoting consistency. I still make mistakes on that and honestly, it's not that useful to be worrying about those syntax details.

So that's why [prettier](https://github.com/prettier/prettier) is pretty cool :)

In this pull request I've parsed the project and also added a node script to lint your TypeScript whenever you want, with:

```
yarn lintjs
```

Also took care of configuring the linter to match your current style as close as possible.

The amount of changes may look scary, but it's all just adding semicolons, rearranging spacing; nothing that changes the actual behavior of the library.

Cheers!