### PR TITLE
Export styles with `.min` extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook:build": "build-storybook -c .storybook -o .out",
     "storybook:github": "storybook-to-ghpages",
-    "prepublishOnly": "export NODE_ENV=production && webpack && ./node_modules/node-sass/bin/node-sass --output-style compressed ./src/sass.scss > ./dist/style.css",
+    "prepublishOnly": "export NODE_ENV=production && webpack && ./node_modules/node-sass/bin/node-sass --output-style compressed ./src/sass.scss > ./dist/style.min.css",
     "lintjs": "prettier --use-tabs --write \"{src,demos}/**/*.{ts,tsx}\" --print-width 120"
   },
   "dependencies": {


### PR DESCRIPTION
It is best practice to export compressed styles with a `.min.css` extension. Several tools use the `.min.css` extension to decide whether preprocessing is necessary.