### PR TITLE
move isLocked logic to models

### DIFF
--- a/src/DiagramEngine.ts
+++ b/src/DiagramEngine.ts
@@ -87,20 +87,6 @@ export class DiagramEngine extends BaseEntity<DiagramEngineListener> {
 			return true;
 		}
 
-		//a point is locked, if its model is locked
-		if (model instanceof PortModel) {
-			if (model.getParent().isLocked()) {
-				return true;
-			}
-		}
-
-		//a point is locked, if its model is locked
-		if (model instanceof PointModel) {
-			if (model.getLink().isLocked()) {
-				return true;
-			}
-		}
-
 		return model.isLocked();
 	}
 

--- a/src/models/PointModel.ts
+++ b/src/models/PointModel.ts
@@ -62,4 +62,8 @@ export class PointModel extends BaseModel<BaseModelListener> {
 	getLink(): LinkModel {
 		return this.link;
 	}
+	
+	isLocked() {
+		return super.isLocked() || this.getLink().isLocked();
+	}
 }

--- a/src/models/PortModel.ts
+++ b/src/models/PortModel.ts
@@ -64,4 +64,8 @@ export class PortModel extends BaseModel<BaseModelListener> {
 		linkModel.setSourcePort(this);
 		return linkModel;
 	}
+
+	isLocked() {
+		return super.isLocked() || this.getParent().isLocked();
+	}
 }


### PR DESCRIPTION
# Checklist
- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer because you are awesome

## What?

Move some isLocked logic to the models so it can be overridden by custom model implementations

## Why?

I needed to have a node that was locked (immovable), but still have the ability to manipulate links from it's port(s). Now I'm able to create a custom PortModel that overrides the default isLocked check.

## How?

Moved the logic into the necessary base model classes

## Feel-Good "programming lol" image:

(Add your own one below :])

![LOL](https://i.redd.it/hvw8yoesaxzz.png)



  