### PR TITLE
fixes #139

### DIFF
--- a/src/defaults/DefaultLinkWidget.tsx
+++ b/src/defaults/DefaultLinkWidget.tsx
@@ -9,7 +9,7 @@ export interface DefaultLinkProps {
 	smooth?: boolean;
 	link: LinkModel;
 	diagramEngine: DiagramEngine;
-	pointAdded?: (point: PointModel, event) => any;
+	pointAdded?: (point: PointModel, event: MouseEvent) => any;
 }
 
 export interface DefaultLinkState {
@@ -40,7 +40,7 @@ export class DefaultLinkWidget extends React.Component<DefaultLinkProps, Default
 		};
 	}
 
-	addPointToLink = (event, index: number): void => {
+	addPointToLink = (event: MouseEvent, index: number): void => {
 		if (
 			!event.shiftKey &&
 			!this.props.diagramEngine.isModelLocked(this.props.link) &&

--- a/src/widgets/LinkLayerWidget.tsx
+++ b/src/widgets/LinkLayerWidget.tsx
@@ -6,7 +6,7 @@ import { PointModel } from "../models/PointModel";
 
 export interface LinkLayerProps {
 	diagramEngine: DiagramEngine;
-	pointAdded: (point: PointModel, event) => any;
+	pointAdded: (point: PointModel, event: MouseEvent) => any;
 }
 
 export interface LinkLayerState {}


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [ ] Had a beer because you are awesome

## What?

Replaces `any` type for `event` in `DefaultLinkProps` & `LinkLayerProps` by `MouseEvent` type.

## Why?

When you use `react-diagrams` in conjunction with a fresh new `create-react-app . --scripts-version=react-scripts-ts` you get an error straight ahead because `DefaultLinkProps` & `LinkLayerProps` have an implicitly `any` type for their `event` param.

## How?

Well, that's pretty straightforward.

## Feel-Good "programming lol" image:

![LOL](https://i.pinimg.com/736x/47/c4/cf/47c4cf58f862a3bd239b3c99fbf0b597--smiling-animals-funny-animals.jpg)


