### PR TITLE
BaseModel extends use T instead of BaseModelListener

### DIFF
--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -15,7 +15,7 @@ export interface BaseModelListener extends BaseListener {
 export class BaseModel<
 	X extends BaseEntity = BaseEntity,
 	T extends BaseModelListener = BaseModelListener
-> extends BaseEntity<BaseModelListener> {
+> extends BaseEntity<T> {
 	type: string;
 	selected: boolean;
 	parent: X;


### PR DESCRIPTION
Use `T` instead otherwise `LinkModelListener` will not be used for `LinkModel`.
Fixes type warning about `link.addListener(...)` argument.
Probably fixes same issue with `link.iterateListeners(...)`.

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x]  The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [ ] Had a beer because you are awesome

I ran `npm test` and one test failed (`simple test › should delete a link and create a new one`) but it seem to fail without my change also. Not sure whats going on.

## What?

Type warning when doing:
```Typscript
link.addListener({
    targetPortChanged: event => {},
    sourcePortChanged: event => {}
});
```

Warning:

```
Argument of type '{ targetPortChanged: (event: any) => void; sourcePortChanged: (event: any) => void; }' is not assignable to parameter of type 'BaseModelListener'.
  Object literal may only specify known properties, and 'targetPortChanged' does not exist in type 'BaseModelListener'.
````

## Why?

Makes the red stuff go away in vscode

## How?

Just change to a `T`

## Feel-Good "programming lol" image:

Not programming but i like capybaras, the biggest and most chilled rodent on earth:

![LOL](https://i.imgur.com/Eh9GKBp.png)


