### PR TITLE
feat(link): improve rendering of vertical links

### DIFF
--- a/src/Toolkit.ts
+++ b/src/Toolkit.ts
@@ -43,9 +43,12 @@ export class Toolkit {
 	}
 
 	public static generateCurvePath(firstPoint: PointModel, lastPoint: PointModel, curvy: number = 0): string {
-		return `M${firstPoint.x},${firstPoint.y} C ${firstPoint.x + curvy},${firstPoint.y} ${lastPoint.x + -curvy},${
-			lastPoint.y
-		} ${lastPoint.x},${lastPoint.y}`;
+		var isHorizontal = Math.abs(firstPoint.x - lastPoint.x) > Math.abs(firstPoint.y - lastPoint.y);
+		var curvyX = isHorizontal ? curvy : 0;
+		var curvyY = isHorizontal ? 0 : curvy;
+
+		return `M${firstPoint.x},${firstPoint.y} C ${firstPoint.x + curvyX},${firstPoint.y + curvyY}
+		${lastPoint.x - curvyX},${lastPoint.y - curvyY} ${lastPoint.x},${lastPoint.y}`;
 	}
 
 	public static generateDynamicPath(pathCoords: number[][]) {

--- a/src/defaults/widgets/DefaultLinkWidget.tsx
+++ b/src/defaults/widgets/DefaultLinkWidget.tsx
@@ -305,10 +305,13 @@ export class DefaultLinkWidget extends BaseWidget<DefaultLinkProps, DefaultLinkS
 		// See @link{#isSmartRoutingApplicable()}.
 		if (paths.length === 0) {
 			if (points.length === 2) {
+				var isHorizontal = Math.abs(points[0].x - points[1].x) > Math.abs(points[0].y - points[1].y);
+				var xOrY = isHorizontal ? "x" : "y";
+
 				//draw the smoothing
 				//if the points are too close, just draw a straight line
 				var margin = 50;
-				if (Math.abs(points[0].x - points[1].x) < 50) {
+				if (Math.abs(points[0][xOrY] - points[1][xOrY]) < 50) {
 					margin = 5;
 				}
 
@@ -317,7 +320,7 @@ export class DefaultLinkWidget extends BaseWidget<DefaultLinkProps, DefaultLinkS
 
 				//some defensive programming to make sure the smoothing is
 				//always in the right direction
-				if (pointLeft.x > pointRight.x) {
+				if (pointLeft[xOrY] > pointRight[xOrY]) {
 					pointLeft = points[1];
 					pointRight = points[0];
 				}


### PR DESCRIPTION
# Checklist

- [X] The code has been run through pretty `yarn run pretty`
- [X] The tests pass on CircleCI
- [X] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [X] The PR Template has been filled out (see below)

## What?

Renders/smoothens the links differently based on their orientation. Effectively improving support for vertical flowing links.

Fixes #172 

## Why?

Because a picture is worth a thousand words:

Left is the current situation, right is with this PR:

![image](https://user-images.githubusercontent.com/1196524/36779834-8fd825aa-1c71-11e8-8d7c-613e5bc8d012.png)


## How?

Compute orientation of the link. Basically, it's a horizontal link, if the span over the x-axis is greater than the spawn over the y-axis. It's a vertical link if not.

Step 2 was adjusting the smoothing and the safety-flip accordingly.


