### PR TITLE
feat(build): add cross-env to support building on various platforms.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"storybook": "start-storybook -p 9001 -c .storybook",
 		"storybook:build": "build-storybook -c .storybook -o .out",
 		"storybook:github": "storybook-to-ghpages",
-		"prepublishOnly": "rm -rf ./dist && export NODE_ENV=production && webpack && ./node_modules/node-sass/bin/node-sass --output-style compressed ./src/sass/main.scss > ./dist/style.min.css",
+		"prepublishOnly": "rm -rf ./dist && cross-env NODE_ENV=production webpack && ./node_modules/node-sass/bin/node-sass --output-style compressed ./src/sass/main.scss > ./dist/style.min.css",
 		"pretty": "prettier --use-tabs --write \"{src,demos}/**/*.{ts,tsx}\" --print-width 120"
 	},
 	"dependencies": {
@@ -49,6 +49,7 @@
 		"@types/puppeteer": "^1.0.0",
 		"@types/react": "^16.0.38",
 		"copy-webpack-plugin": "^4.4.2",
+		"cross-env": "^5.1.3",
 		"css-loader": "^0.28.10",
 		"dagre": "^0.8.2",
 		"enzyme": "^3.3.0",


### PR DESCRIPTION
# Checklist

- [X] The code has been run through pretty `yarn run pretty`
- [X] The tests pass on CircleCI
- [X] The PR Template has been filled out (see below)

## What?

Set ENV vars in the `scripts` section of `package.json` with `cross-env` instead of `export FOO=BAR`.

## Why?

So we support multiple build environments. We don't need to decide if we build for Windows with `set FOO=BAR` or for Linux with `export FOO=BAR`. Cross-env handles it for us.

## How?

Install cross-env as dev-dependency, and adjust scripts accordiginly.

```
yarn add -D cross-env
```

```diff
scripts: {
- build: "export NODE_ENV=production && webpack",
+ build: "cross-env NODE_ENV=production webpack",
}
```

