### PR TITLE
feat(events): add `positionChanged` event to `NodeModel`

### DIFF
--- a/src/defaults/models/DefaultNodeModel.ts
+++ b/src/defaults/models/DefaultNodeModel.ts
@@ -1,14 +1,14 @@
 import { DefaultPortModel } from "./DefaultPortModel";
 import * as _ from "lodash";
 
-import { NodeModel } from "../../models/NodeModel";
+import { NodeModel, NodeModelListener } from "../../models/NodeModel";
 import { Toolkit } from "../../Toolkit";
 import { DiagramEngine } from "../../DiagramEngine";
 
 /**
  * @author Dylan Vorster
  */
-export class DefaultNodeModel extends NodeModel {
+export class DefaultNodeModel extends NodeModel<NodeModelListener> {
 	name: string;
 	color: string;
 	ports: { [s: string]: DefaultPortModel };

--- a/src/models/NodeModel.ts
+++ b/src/models/NodeModel.ts
@@ -1,10 +1,16 @@
+import { BaseEvent } from "../BaseEntity";
 import { BaseModel, BaseModelListener } from "./BaseModel";
+import { LinkModel, LinkModelListener } from "./LinkModel";
 import { PortModel } from "./PortModel";
 import * as _ from "lodash";
 import { DiagramEngine } from "../DiagramEngine";
 import { DiagramModel } from "./DiagramModel";
 
-export class NodeModel extends BaseModel<DiagramModel, BaseModelListener> {
+export interface NodeModelListener extends BaseModelListener {
+	positionChanged?(event: BaseEvent<NodeModel>): void;
+}
+
+export class NodeModel<T extends NodeModelListener = NodeModelListener> extends BaseModel<DiagramModel, T> {
 	x: number;
 	y: number;
 	extras: any;
@@ -36,6 +42,12 @@ export class NodeModel extends BaseModel<DiagramModel, BaseModelListener> {
 
 		this.x = x;
 		this.y = y;
+	}
+
+	positionChanged() {
+		this.iterateListeners(
+			(listener: NodeModelListener, event) => listener.positionChanged && listener.positionChanged(event)
+		);
 	}
 
 	getSelectedEntities() {

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -257,8 +257,10 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 					model.model.x = diagramModel.getGridPosition(model.initialX + amountX / amountZoom);
 					model.model.y = diagramModel.getGridPosition(model.initialY + amountY / amountZoom);
 
-					// update port coordinates as well
 					if (model.model instanceof NodeModel) {
+						model.model.positionChanged();
+
+						// update port coordinates as well
 						_.forEach(model.model.getPorts(), port => {
 							const portCoords = this.props.diagramEngine.getPortCoords(port);
 							port.updateCoords(portCoords);


### PR DESCRIPTION
# Checklist

- [X] The code has been run through pretty `yarn run pretty`
- [X] The tests pass on CircleCI
- [X] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [X] The PR Template has been filled out (see below)

## What?

Trigger a `positionChanged` event when moving a `Node` that has the listener assigned.

## Why?

Because I don't need to serialize the whole document structure, but I do want to sync the x/y position of nodes. It could even be used to synchronize multiple users (trough websockets), so they can collaborate on the same diagram.

## How?

Added an event interface to the `NodeModel` and made it so that `DiagramWidget` informs the `NodeModel` when it's moving. Like all other events; it's up to the end user to throttle/debounce the emitted vents.

