### PR TITLE
Change UglifyJsPlugin's ECMAScript target version to 5

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,17 @@
 const webpack = require("webpack");
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 var path = require("path");
 var plugins = [];
-const production = process.env.NODE_ENV === 'production';
+const production = process.env.NODE_ENV === "production";
 
 //do we minify it all
 if (production) {
 	console.log("creating production build");
-	plugins.push(new webpack.DefinePlugin({
-		'process.env.NODE_ENV': '"production"',
-	}));
+	plugins.push(
+		new webpack.DefinePlugin({
+			"process.env.NODE_ENV": '"production"'
+		})
+	);
 }
 
 /**
@@ -18,52 +20,52 @@ if (production) {
 module.exports =
 	//for building the umd distribution
 	{
-		entry: './src/main.ts',
+		entry: "./src/main.ts",
 		output: {
-			filename: 'main.js',
-			path: __dirname + '/dist',
-			libraryTarget: 'umd',
-			library: 'storm-react-diagrams'
+			filename: "main.js",
+			path: __dirname + "/dist",
+			libraryTarget: "umd",
+			library: "storm-react-diagrams"
 		},
 		externals: {
 			react: {
-				root: 'React',
-				commonjs2: 'react',
-				commonjs: 'react',
-				amd: 'react'
+				root: "React",
+				commonjs2: "react",
+				commonjs: "react",
+				amd: "react"
 			},
-			'react-dom': {
-				root: 'ReactDOM',
-				commonjs2: 'react-dom',
-				commonjs: 'react-dom',
-				amd: 'react-dom'
+			"react-dom": {
+				root: "ReactDOM",
+				commonjs2: "react-dom",
+				commonjs: "react-dom",
+				amd: "react-dom"
 			},
-			"lodash": {
-				commonjs: 'lodash',
-				commonjs2: 'lodash',
-				amd: '_',
-				root: '_'
+			lodash: {
+				commonjs: "lodash",
+				commonjs2: "lodash",
+				amd: "_",
+				root: "_"
 			}
 		},
 		plugins: plugins,
 		module: {
 			rules: [
 				{
-					enforce: 'pre',
+					enforce: "pre",
 					test: /\.js$/,
 					loader: "source-map-loader"
 				},
 				{
 					test: /\.tsx?$/,
-					loader: 'awesome-typescript-loader'
+					loader: "awesome-typescript-loader"
 				}
 			]
 		},
 		resolve: {
 			extensions: [".tsx", ".ts", ".js"]
 		},
-		devtool: production ? 'source-map' : 'cheap-module-source-map',
-		mode: production ? 'production' : 'development',
+		devtool: production ? "source-map" : "cheap-module-source-map",
+		mode: production ? "production" : "development",
 		optimization: {
 			minimizer: [
 				// we specify a custom UglifyJsPlugin here to get source maps in production
@@ -76,6 +78,5 @@ module.exports =
 					sourceMap: true
 				})
 			]
-		},
-	}
-;
+		}
+	};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,7 +72,7 @@ module.exports =
 				new UglifyJsPlugin({
 					uglifyOptions: {
 						compress: false,
-						ecma: 6,
+						ecma: 5,
 						mangle: false
 					},
 					sourceMap: true


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [ ] Had a beer because you are awesome

## What?

Change UglifyJsPlugin's ECMAScript target version to 5

## Why?

My team is using Create React App (CRA) for our current project and is unable to run the `react-scripts build` command because the version of UglifyJS included with the CRA tooling only supports ES5 and throws errors when it comes across ES6.

As described in the Create React App docs [here](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify), while Node and modern browsers are doing great with ES6 support and beyond, build tools still need a bit more time to catch up. By setting the build target to ES5, it ensures greater support with current build tools. Another option would be to have multiple build targets for ES5 and ES6+. 

## How?

Changed a 6️⃣ to a 5️⃣.

## Feel-Good "programming lol" image:

![LOL](https://i.redd.it/kmg2nf2efxm01.jpg)


