### PR TITLE
Always remove link from old source/target port on port change

### DIFF
--- a/src/models/LinkModel.ts
+++ b/src/models/LinkModel.ts
@@ -151,10 +151,9 @@ export class LinkModel<T extends LinkModelListener = LinkModelListener> extends 
 	setSourcePort(port: PortModel) {
 		if (port !== null) {
 			port.addLink(this);
-		} else if (this.sourcePort !== null) {
+		}
+		if (this.sourcePort !== null) {
 			this.sourcePort.removeLink(this);
-		} else {
-			return;
 		}
 		this.sourcePort = port;
 		this.iterateListeners((listener: LinkModelListener, event) => {
@@ -175,10 +174,9 @@ export class LinkModel<T extends LinkModelListener = LinkModelListener> extends 
 	setTargetPort(port: PortModel) {
 		if (port !== null) {
 			port.addLink(this);
-		} else if (this.targetPort !== null) {
+		}
+		if (this.targetPort !== null) {
 			this.targetPort.removeLink(this);
-		} else {
-			return;
 		}
 		this.targetPort = port;
 		this.iterateListeners((listener: LinkModelListener, event) => {


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer because you are awesome

## What?

I noticed a issue when using `maximumLinks=1` ports and `allowLooseLinks=false`. Creating a new deatched link from a port that already have a link seems to don't properly remove the link and also end up with a link with same source/target port.

## How?

Steps to reproduce with storybook example:

1. From Node 1 out port drag a new link somewhere and don't attach it to Node 2. Now the existing link have been removed and there is no link between Node 1 and Node 2 anymore.
2. Try to move Node 2. `Uncaught TypeError: Cannot read property 'getID' of null` exception is thrown.

```Typescript
import { DiagramEngine, DiagramModel, DefaultNodeModel, LinkModel, DiagramWidget } from "storm-react-diagrams";
import * as React from "react";

export default () => {
	//1) setup the diagram engine
	var engine = new DiagramEngine();
	engine.installDefaultFactories();

	//2) setup the diagram model
	var model = new DiagramModel();

	//3-A) create a default node
	var node1 = new DefaultNodeModel("Node 1", "rgb(0,192,255)");
	var port1 = node1.addOutPort("Out");
	node1.setPosition(100, 100);
	port1.maximumLinks = 1;

	//3-B) create another default node
	var node2 = new DefaultNodeModel("Node 2", "rgb(192,255,0)");
	var port2 = node2.addInPort("In");
	port2.maximumLinks = 1;
	node2.setPosition(400, 100);

	//3-C) link the 2 nodes together
	var link1 = port2.link(port1);

	//4) add the models to the root graph
	model.addAll(node1, node2, link1);

	//5) load model into engine
	engine.setDiagramModel(model);

	//6) render the diagram!
	return <DiagramWidget className="srd-demo-canvas" diagramEngine={engine} allowLooseLinks={false} />;
};
```

The problem seems to be in `LinkModel` `setSourcePort`/`setTargetPort ` where the link is only removed from the old port if the new port is null. Should always be removed i guess?

Im a bit unsure how the `targetPortChanged` is suppose to work. Should listeners be notified even if the port value did not change? previous code seems to always notify except when new and old port both is null. New code always notifies even if value is the same. Always notify or skip if both null or same port id?
