### PR TITLE
Allow loose links fix and refactor (Fix for #171)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/main.js
 dist/main.js.map
 /package
 *.tgz
+@types/
 
 .out
 

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -375,9 +375,9 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 					return;
 				}
 
-				var link = model.model.getLink();
-				var sourcePort: PortModel = link.getSourcePort();
-				var targetPort: PortModel = link.getTargetPort();
+				let link: LinkModel = model.model.getLink();
+				let sourcePort: PortModel = link.getSourcePort();
+				let targetPort: PortModel = link.getTargetPort();
 				if (sourcePort !== null && targetPort !== null) {
 					if (!sourcePort.canLinkToPort(targetPort)) {
 						//link not allowed

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -315,14 +315,12 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 		//are we going to connect a link to something?
 		if (this.state.action instanceof MoveItemsAction) {
 			var element = this.getMouseElement(event);
-			var linkConnected = false;
 			_.forEach(this.state.action.selectionModels, model => {
 				//only care about points connecting to things
 				if (!(model.model instanceof PointModel)) {
 					return;
 				}
 				if (element && element.model instanceof PortModel && !diagramEngine.isModelLocked(element.model)) {
-					linkConnected = true;
 					let link = model.model.getLink();
 					if (link.getTargetPort() !== null) {
 						//if this was a valid link already and we are adding a node in the middle, create 2 links from the original
@@ -347,22 +345,19 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 					}
 					delete this.props.diagramEngine.linksThatHaveInitiallyRendered[link.getID()];
 				}
-				//if we moved a NodeModel and allowLooseLinks is false, we know that any links involved were valid
-				if ((!this.props.allowLooseLinks && element.model instanceof NodeModel) || !this.state.wasMoved) {
-					linkConnected = true;
-				}
 			});
 
-			//do we want to allow loose links on the diagram model or not
-			if (!linkConnected && !this.props.allowLooseLinks) {
+			//check for / remove any loose links in any models which have been moved
+			if (!this.props.allowLooseLinks && this.state.wasMoved) {
 				_.forEach(this.state.action.selectionModels, model => {
 					//only care about points connecting to things
 					if (!(model.model instanceof PointModel)) {
 						return;
 					}
 
-					var link = model.model.getLink();
-					if (link.isLastPoint(model.model)) {
+					let selectedPoint: PointModel = model.model;
+					let link: LinkModel = selectedPoint.getLink();
+					if (link.getSourcePort() === null || link.getTargetPort() === null) {
 						link.remove();
 					}
 				});

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -267,7 +267,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 						diagramEngine.calculateRoutingMatrix();
 					}
 				} else if (model.model instanceof PointModel) {
-					// we want points that are connected to ports, to not neccesarilly snap to grid
+					// we want points that are connected to ports, to not necessarily snap to grid
 					// this stuff needs to be pixel perfect, dont touch it
 					model.model.x = model.initialX + diagramModel.getGridPosition(amountX / amountZoom);
 					model.model.y = model.initialY + diagramModel.getGridPosition(amountY / amountZoom);

--- a/tests/e2e/E2EHelper.ts
+++ b/tests/e2e/E2EHelper.ts
@@ -58,6 +58,25 @@ export class E2EPort extends E2EElement {
 			_.difference(_.flatMap((await this.parent.model()).ports, "links"), currentLinks)[0]
 		);
 	}
+
+	async linkToPoint(x: number, y: number): Promise<E2ELink> {
+		let currentLinks = _.flatMap((await this.parent.model()).ports, "links");
+
+		let bounds = await this.element.boundingBox();
+
+		// click on this port
+		this.page.mouse.move(bounds.x, bounds.y);
+		this.page.mouse.down();
+
+		// drag to point
+		this.page.mouse.move(x, y);
+		this.page.mouse.up();
+
+		// get the parent to get the link
+		return await this.helper.link(
+			_.difference(_.flatMap((await this.parent.model()).ports, "links"), currentLinks)[0]
+		);
+	}
 }
 
 export class E2ELink extends E2EElement {

--- a/tests/e2e/simple-flow.test.ts
+++ b/tests/e2e/simple-flow.test.ts
@@ -1,0 +1,60 @@
+import "jest";
+import * as puppeteer from "puppeteer";
+import { E2EHelper } from "./E2EHelper";
+
+var browser;
+
+async function itShould(demo: string, directive, test: (page: puppeteer.Page, helper: E2EHelper) => any) {
+	it(directive, async () => {
+		let page = await browser.newPage();
+		await page.goto("file://" + __dirname + "/../../dist/e2e/" + demo + "/index.html");
+		let helper = new E2EHelper(page);
+		await test(page, helper);
+		await page.close();
+	});
+}
+
+beforeAll(async () => {
+	if (process.env.CIRCLECI) {
+		console.log("using CircleCI");
+
+		browser = await puppeteer.launch({
+			args: ["--no-sandbox", "--disable-setuid-sandbox"]
+		});
+	} else {
+		browser = await puppeteer.launch({
+			headless: false
+		});
+	}
+});
+
+afterAll(() => {
+	browser.close();
+});
+
+describe("simple flow test", async () => {
+	itShould("demo-simple-flow", "drag link to port adds a link", async (page, helper) => {
+		// create a new link
+		let node1 = await helper.node("6");
+		let node2 = await helper.node("9");
+
+		let port1 = await node1.port("7");
+		let port2 = await node2.port("10");
+
+		let newlink = await port1.link(port2);
+		await expect(await newlink.exists()).toBeTruthy();
+	});
+
+	itShould("demo-simple-flow", "drag link to node does not add a link", async (page, helper) => {
+		// create a new link
+		let node1 = await helper.node("6");
+		let node2 = await helper.node("9");
+
+		let port1 = await node1.port("7");
+
+		let node2Bounds = await node2.element.boundingBox();
+
+		let newlink = await port1.linkToPoint(node2Bounds.x, node2Bounds.y);
+		await expect(await newlink.exists()).toBeFalsy();
+	});
+});


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)

## What?

A refactor of the validation logic for the "allowLooseLinks" functionality. Fixes issue #171.

The auto-generated directory "@types" has been added to the .gitignore file. (Generated by VS Code)

Added some E2E tests for this specific bit of functionality, but for some reason I couldn't get any of the E2E tests to run. (jest.config.js is not set to pickup *.test.js files and when I modified it to do so, I received a not found error.)

Also corrected a typo and used let in a few places to match the rest of the code base.

## Why?

The logic previously relied on a "linkConnected" which was updated as changes were made, but this did not take into account some edge cases such as dragging links onto nodes (But not ports) and moving nodes with connected links.

## How?

We now validate that any links for any points which have been moved are connected to ports on both ends. This also makes the validation more robust to for any future changes in this area.

## Feel-Good "programming lol" image:

![LOL](https://scontent-sea1-1.cdninstagram.com/vp/11413d39a365adb159ed68e63210c541/5B739895/t51.2885-15/e35/10431981_509098329245843_1413496426_n.jpg?se=7&ig_cache_key=MTA1MDkwMjU4ODM5Mzk2NDE3Ng%3D%3D.2)


