### PR TITLE
on deserialization of diagram, labels are not getting rendered bug re…

### DIFF
--- a/src/defaults/models/DefaultLabelModel.tsx
+++ b/src/defaults/models/DefaultLabelModel.tsx
@@ -1,4 +1,6 @@
 import { LabelModel } from "../../models/LabelModel";
+import * as _ from "lodash";
+import { DiagramEngine } from "../../DiagramEngine";
 
 export class DefaultLabelModel extends LabelModel {
 	label: string;
@@ -10,5 +12,16 @@ export class DefaultLabelModel extends LabelModel {
 
 	setLabel(label: string) {
 		this.label = label;
+	}
+
+	deSerialize(ob, engine: DiagramEngine) {
+		super.deSerialize(ob, engine);
+		this.label = ob.label;
+	}
+
+	serialize() {
+		return _.merge(super.serialize(), {
+			label: this.label
+		});
 	}
 }

--- a/src/models/LabelModel.ts
+++ b/src/models/LabelModel.ts
@@ -1,5 +1,7 @@
 import { BaseModel } from "./BaseModel";
 import { LinkModel } from "./LinkModel";
+import * as _ from "lodash";
+import { DiagramEngine } from "../DiagramEngine";
 
 export class LabelModel extends BaseModel<LinkModel> {
 	offsetX: number;
@@ -9,5 +11,18 @@ export class LabelModel extends BaseModel<LinkModel> {
 		super(type, id);
 		this.offsetX = 0;
 		this.offsetY = 0;
+	}
+
+	deSerialize(ob, engine: DiagramEngine) {
+		super.deSerialize(ob, engine);
+		this.offsetX = ob.offsetX;
+		this.offsetY = ob.offsetY;
+	}
+
+	serialize() {
+		return _.merge(super.serialize(), {
+			offsetX: this.offsetX,
+			offsetY: this.offsetY
+		});
 	}
 }


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer because you are awesome

## What?

On serialization of diagram model, label information didn't get added to its model. so on deserialization, it was not able to render label with same information

## Why?

Serialization and Deserialization methods are not available for `LabelModel `and `DefaultLabelModel` 

## How?

Added Serialization and Deserialization methods are for `LabelModel `and `DefaultLabelModel`



