### PR TITLE
Allows links to be left-clicked and deleted

### DIFF
--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -476,7 +476,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 				}}
 				onMouseDown={event => {
 					if (event.nativeEvent.which === 3) return;
-					this.setState({ ...this.state, wasMoved: false });
+					this.setState({ wasMoved: false });
 
 					diagramEngine.clearRepaintEntities();
 					var model = this.getMouseElement(event);
@@ -526,8 +526,6 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 							diagramModel.clearSelection();
 						}
 						model.model.setSelected(true);
-
-						this.startFiringAction(new MoveItemsAction(event.clientX, event.clientY, diagramEngine));
 					}
 					this.state.document.addEventListener("mousemove", this.onMouseMove);
 					this.state.document.addEventListener("mouseup", this.onMouseUp);
@@ -539,11 +537,8 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 						pointAdded={(point: PointModel, event) => {
 							this.state.document.addEventListener("mousemove", this.onMouseMove);
 							this.state.document.addEventListener("mouseup", this.onMouseUp);
-							event.stopPropagation();
 							diagramModel.clearSelection(point);
-							this.setState({
-								action: new MoveItemsAction(event.clientX, event.clientY, diagramEngine)
-							});
+							this.startFiringAction(new MoveItemsAction(event.clientX, event.clientY, diagramEngine));
 						}}
 					/>
 				)}


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer because you are awesome (:heart:)

## What?

You can now left click a link to select it (for deletion)!

## Why?

Right now, selecting links for deletion is inconvenient. You have to "shift-click" to select it, which is :cry: for two reasons:
* It's not obvious that "shift" is required to select the link
* If you have a widget clicked from the previous task you were doing, then shift-click to delete a link, then you just accidentally deleted the link _and_ the widget that (perhaps unbeknownst to you) remained selected

## How?

I ensured that the "link" was still `selected` when the `MoveItemsAction` was triggered. Additionally, I removed a bug where `this.setState(...this.state, ...)` was called during the same JS "tick" as another `this.setState(...)`, causing the first one's changes to be ignored (since all of `this.state` was being explicitly set).

## Feel-Good "programming lol" image:

![poppin](https://user-images.githubusercontent.com/7784737/44177903-b9f93d80-a0a4-11e8-8b85-a8b7706038ed.gif)

And, of course, thank you for the sick library!
![thank-u-nice-work](https://user-images.githubusercontent.com/7784737/44177906-bc5b9780-a0a4-11e8-8026-4b204446c1e9.jpeg)

-----

Note: this doesn't fully take care of #49, since when you left-click, it still creates the point. (It doesn't matter for us delete-ers out there, since the point is deleted with the link, but just being pedantic so it's clear)


