### PR TITLE
Add optional `id` argument to `DefaultNodeModel` constructor

### DIFF
--- a/src/defaults/models/DefaultNodeModel.ts
+++ b/src/defaults/models/DefaultNodeModel.ts
@@ -13,8 +13,8 @@ export class DefaultNodeModel extends NodeModel {
 	color: string;
 	ports: { [s: string]: DefaultPortModel };
 
-	constructor(name: string = "Untitled", color: string = "rgb(0,192,255)") {
-		super("default");
+	constructor(name: string = "Untitled", color: string = "rgb(0,192,255)", id?: string) {
+		super("default", id);
 		this.name = name;
 		this.color = color;
 	}


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a ~beer~ vodka because you are awesome

This fixes issue #308.

## What?

Adds an optional ID argument to the `DefaultNodeModel` and passes it to the `NodeModel` model constructor via `super`.

## Why?

Stateless functions cause node IDs to be regenerated on every render and references to the previous nodes is lost. IDs can now be kept consistent across renders if they are managed manually.

## How?

By decompiling the typescript code to basic binary, adding a specific set of 1's and 0's then recompiling the binary into typescript.

## Feel-Good "programming lol" image:

It's not programming related but I've wanted to post this picture forever.

![LOL](https://i.redd.it/rlspb0d4i5q11.png)


