### PR TITLE
fix line direction while maintaining smoothening

### DIFF
--- a/src/Toolkit.ts
+++ b/src/Toolkit.ts
@@ -45,8 +45,18 @@ export class Toolkit {
 
 	public static generateCurvePath(firstPoint: PointModel, lastPoint: PointModel, curvy: number = 0): string {
 		var isHorizontal = Math.abs(firstPoint.x - lastPoint.x) > Math.abs(firstPoint.y - lastPoint.y);
-		var curvyX = isHorizontal ? curvy : 0;
-		var curvyY = isHorizontal ? 0 : curvy;
+
+		var xOrY = isHorizontal ? "x" : "y";
+
+		// make sure that smoothening works
+		// without disrupting the line direction
+		let curvyness = curvy;
+		if (firstPoint[xOrY] > firstPoint[xOrY]) {
+			curvyness = -curvy;
+		}
+
+		var curvyX = isHorizontal ? curvyness : 0;
+		var curvyY = isHorizontal ? 0 : curvyness;
 
 		return `M${firstPoint.x},${firstPoint.y} C ${firstPoint.x + curvyX},${firstPoint.y + curvyY}
     ${lastPoint.x - curvyX},${lastPoint.y - curvyY} ${lastPoint.x},${lastPoint.y}`;

--- a/src/defaults/widgets/DefaultLinkWidget.tsx
+++ b/src/defaults/widgets/DefaultLinkWidget.tsx
@@ -318,13 +318,6 @@ export class DefaultLinkWidget extends BaseWidget<DefaultLinkProps, DefaultLinkS
 				var pointLeft = points[0];
 				var pointRight = points[1];
 
-				//some defensive programming to make sure the smoothing is
-				//always in the right direction
-				if (pointLeft[xOrY] > pointRight[xOrY]) {
-					pointLeft = points[1];
-					pointRight = points[0];
-				}
-
 				paths.push(
 					this.generateLink(
 						Toolkit.generateCurvePath(pointLeft, pointRight, this.props.link.curvyness),


### PR DESCRIPTION
# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [ ] The PR Template has been filled out (see below)
- [ ] Had a beer because you are awesome

## What?

Fix the path direction for line while maintaining proper smoothening.

## Why?

Because animated links and link arrows sometimes point in the wrong direction.

## How?

To maintain smoothening of link, I changed the curvyness to negative instead of reversing the start and end points.

