### PR TITLE
Allows for custom portIds

### DIFF
--- a/src/DiagramEngine.ts
+++ b/src/DiagramEngine.ts
@@ -551,18 +551,20 @@ export class DiagramEngine extends BaseEntity<DiagramEngineListener> {
 		const allElements = _.flatMap(
 			_.values(this.diagramModel.links).map(link => [].concat(link.sourcePort, link.targetPort))
 		);
-		allElements.filter(port => port !== null).forEach(port => {
-			const startX = Math.floor(port.x / ROUTING_SCALING_FACTOR);
-			const endX = Math.ceil((port.x + port.width) / ROUTING_SCALING_FACTOR);
-			const startY = Math.floor(port.y / ROUTING_SCALING_FACTOR);
-			const endY = Math.ceil((port.y + port.height) / ROUTING_SCALING_FACTOR);
+		allElements
+			.filter(port => port !== null)
+			.forEach(port => {
+				const startX = Math.floor(port.x / ROUTING_SCALING_FACTOR);
+				const endX = Math.ceil((port.x + port.width) / ROUTING_SCALING_FACTOR);
+				const startY = Math.floor(port.y / ROUTING_SCALING_FACTOR);
+				const endY = Math.ceil((port.y + port.height) / ROUTING_SCALING_FACTOR);
 
-			for (let x = startX - 1; x <= endX + 1; x++) {
-				for (let y = startY - 1; y < endY + 1; y++) {
-					this.markMatrixPoint(matrix, this.translateRoutingX(x), this.translateRoutingY(y));
+				for (let x = startX - 1; x <= endX + 1; x++) {
+					for (let y = startY - 1; y < endY + 1; y++) {
+						this.markMatrixPoint(matrix, this.translateRoutingX(x), this.translateRoutingY(y));
+					}
 				}
-			}
-		});
+			});
 	};
 
 	markMatrixPoint = (matrix: number[][], x: number, y: number) => {

--- a/src/defaults/models/DefaultNodeModel.ts
+++ b/src/defaults/models/DefaultNodeModel.ts
@@ -19,12 +19,12 @@ export class DefaultNodeModel extends NodeModel<NodeModelListener> {
 		this.color = color;
 	}
 
-	addInPort(label: string): DefaultPortModel {
-		return this.addPort(new DefaultPortModel(true, Toolkit.UID(), label));
+	addInPort(label: string, id: string = ""): DefaultPortModel {
+		return this.addPort(new DefaultPortModel(true, id || Toolkit.UID(), label));
 	}
 
-	addOutPort(label: string): DefaultPortModel {
-		return this.addPort(new DefaultPortModel(false, Toolkit.UID(), label));
+	addOutPort(label: string, id: string = ""): DefaultPortModel {
+		return this.addPort(new DefaultPortModel(false, id || Toolkit.UID(), label));
 	}
 
 	deSerialize(object, engine: DiagramEngine) {


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer [or two] because you are awesome

## What?
Enables customId when instantiating a port 
## Why?
It allows easy parsing of port relationships 

## How?
Added params for id in the default port method

## Feel-Good "programming lol" image:
![#truefacts](https://cdn-images-1.medium.com/max/1600/1*MAQ2E9rXy7DwaZPX5K78wA.jpeg)


