### PR TITLE
fixed path issue in lib-routing/src/link/PathFindingLinkWidget.tsx

### DIFF
--- a/lib-routing/src/link/PathFindingLinkWidget.tsx
+++ b/lib-routing/src/link/PathFindingLinkWidget.tsx
@@ -4,7 +4,7 @@ import { DiagramEngine } from '@projectstorm/react-diagrams-core';
 import PathFinding from '../engine/PathFinding';
 import { PathFindingLinkFactory } from './PathFindingLinkFactory';
 import { PathFindingLinkModel } from './PathFindingLinkModel';
-import { DefaultLinkSegmentWidget } from '@projectstorm/react-diagrams-defaults/src/link/DefaultLinkSegmentWidget';
+import { DefaultLinkSegmentWidget } from '@projectstorm/react-diagrams-defaults';
 
 export interface PathFindingLinkWidgetProps {
 	color?: string;


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI (some things are failing not related to this)
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer [or two] because you are awesome

## What?
Fixed import path
## Why?
So the routing library will work 

## How?
deleted a few chars

## Feel-Good "programming lol" image:
![#truefacts](https://cdn-images-1.medium.com/max/1600/1*MAQ2E9rXy7DwaZPX5K78wA.jpeg)
