### PR TITLE
Fix bug where labels do not overflow

### DIFF
--- a/src/defaults/widgets/DefaultLinkWidget.tsx
+++ b/src/defaults/widgets/DefaultLinkWidget.tsx
@@ -120,13 +120,12 @@ export class DefaultLinkWidget extends BaseWidget<DefaultLinkProps, DefaultLinkS
 	}
 
 	generateLabel(label: LabelModel) {
-		const canvas = this.props.diagramEngine.canvas as HTMLElement;
 		return (
 			<foreignObject
 				key={label.id}
 				className={this.bem("__label")}
-				width={canvas.offsetWidth}
-				height={canvas.offsetHeight}
+				width="1"
+				height="1"
 			>
 				<div ref={ref => (this.refLabels[label.id] = ref)}>
 					{this.props.diagramEngine

--- a/src/sass/defaults/_DefaultLinkWidget.scss
+++ b/src/sass/defaults/_DefaultLinkWidget.scss
@@ -22,6 +22,7 @@
 
   &__label {
     pointer-events: none;
+    overflow: visible !important;
 
     > div{
       display: inline-block;


### PR DESCRIPTION
# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer because you are awesome

## What?

Fixes a bug where default labels do not overflow if the links are moved out of the foreignObject

The bug can be seen on http://projectstorm.cloud/react-diagrams/?path=/story/simple-usage--simple-example

Screenshot:
![Screenshot](https://i.imgur.com/SDdjN8O.png)

## Why?

Because it was a bug

## How?

Set the `overflow: visible` for the foreignObject, and set the width and height to 1 because it doesn't matter anymore 

## Feel-Good "programming lol" image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


