### PR TITLE
enable 100% height of parrent for canvas

### DIFF
--- a/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
+++ b/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
@@ -11,6 +11,7 @@ export interface DiagramProps {
 
 namespace S {
 	export const Canvas = styled.div`
+		height: 100%;
 		position: relative;
 		cursor: move;
 		overflow: hidden;


### PR DESCRIPTION
# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
100% height for canvas. 

## Why?
I have troubles with canvas visibility

<div style={{height: '600px'}}>
     <CanvasWidget engine={this.engine} />
</div>

If Height of canvas div is not 100% canvas is not visible and I can't see nodes. SInce from version 6 there is **@emotion/styled** used for element style I cannot override it in css. It has no dependency for storybook demos.

## How?
 

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


