### PR TITLE
Export DragDiagramItemsState

### DIFF
--- a/packages/react-diagrams-core/index.ts
+++ b/packages/react-diagrams-core/index.ts
@@ -19,6 +19,7 @@ export * from './src/entities/port/PortModel';
 export * from './src/entities/port/PortWidget';
 
 export * from './src/states/DefaultDiagramState';
+export * from './src/states/DragDiagramItemsState';
 export * from './src/states/DragNewLinkState';
 
 export * from './src/DiagramEngine';


### PR DESCRIPTION
Export DragDiagramItemsState in the react-diagrams-core's index

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Export DefaultDiagramState in react-diagrams-core's index.

## Why?
so that custom DiagramState could use it.

## How?
 

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


