### PR TITLE
fix diagrams-demo-gallery generation issue on windows and use resize-observer-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"react-dom": "^16.8.6",
 		"react-syntax-highlighter": "^11.0.2",
 		"react-test-renderer": "^16.8.6",
+		"resize-observer-polyfill": "^1.5.1",
 		"source-map-loader": "^0.2.4",
 		"storybook-host": "^5.1.0",
 		"storybook-readme": "^5.0.5",

--- a/packages/diagrams-demo-gallery/.storybook/webpack.config.js
+++ b/packages/diagrams-demo-gallery/.storybook/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = async ({ config, mode }) => {
 						enforce: 'pre',
 						test: /\.js$/,
 						loader: 'source-map-loader',
-						exclude: [/node_modules\//]
+						exclude: [/node_modules/]
 					},
 					{
 						test: /\.tsx?$/,

--- a/packages/react-diagrams-core/package.json
+++ b/packages/react-diagrams-core/package.json
@@ -37,5 +37,8 @@
 		"lodash": "4.*",
 		"react": "16.*"
 	},
-	"gitHead": "bb878657ba0c2f81764f32901fd96158a0f8352e"
+	"gitHead": "bb878657ba0c2f81764f32901fd96158a0f8352e",
+	"devDependencies": {
+		"resize-observer-polyfill": "^1.5.1"
+	}
 }

--- a/packages/react-diagrams-core/package.json
+++ b/packages/react-diagrams-core/package.json
@@ -35,10 +35,8 @@
 	"peerDependencies": {
 		"closest": "^0.0.1",
 		"lodash": "4.*",
-		"react": "16.*"
-	},
-	"gitHead": "bb878657ba0c2f81764f32901fd96158a0f8352e",
-	"devDependencies": {
+		"react": "16.*",
 		"resize-observer-polyfill": "^1.5.1"
-	}
+	},
+	"gitHead": "bb878657ba0c2f81764f32901fd96158a0f8352e"
 }

--- a/packages/react-diagrams-core/src/entities/node/NodeWidget.tsx
+++ b/packages/react-diagrams-core/src/entities/node/NodeWidget.tsx
@@ -4,6 +4,7 @@ import { DiagramEngine } from '../../DiagramEngine';
 import { NodeModel } from './NodeModel';
 import { BaseEntityEvent, BaseModel, ListenerHandle, PeformanceWidget } from '@projectstorm/react-canvas-core';
 import styled from '@emotion/styled';
+import ResizeObserver from 'resize-observer-polyfill';
 
 export interface NodeProps {
 	node: NodeModel;


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

- Fix `source-map-loader` exclude path pattern to avoid `module not found` errors on Windows because it uses backslash instead of slash.
- Fix `ResizeObserver` not defined issue on major browsers which do not support that feature currently. #404 

## Why?

See above.

## How?
 
See diff.

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


