### PR TITLE
fix for unique key maps

### DIFF
--- a/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
+++ b/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
@@ -93,7 +93,7 @@ export class CanvasWidget extends React.Component<DiagramProps> {
 				}}>
 				{model.getLayers().map(layer => {
 					return (
-						<TransformLayerWidget layer={layer}>
+						<TransformLayerWidget layer={layer} key={layer.getID()}>
 							<SmartLayerWidget layer={layer} engine={this.props.engine} key={layer.getID()} />
 						</TransformLayerWidget>
 					);

--- a/packages/react-diagrams-defaults/src/node/DefaultNodeWidget.tsx
+++ b/packages/react-diagrams-defaults/src/node/DefaultNodeWidget.tsx
@@ -61,7 +61,7 @@ export interface DefaultNodeProps {
  */
 export class DefaultNodeWidget extends React.Component<DefaultNodeProps> {
 	generatePort = port => {
-		return <DefaultPortLabel engine={this.props.engine} port={port} key={port.id} />;
+		return <DefaultPortLabel engine={this.props.engine} port={port} key={port.getID()} />;
 	};
 
 	render() {


### PR DESCRIPTION
This is a fix for `each child in list should have a unique key prop` detailed here: 
https://github.com/projectstorm/react-diagrams/issues/407

This only fixes the unique key prop errors, however the `:first-child` error also mentioned in that issue still needs to be addressed which is being caused by

https://github.com/projectstorm/react-diagrams/blob/master/packages/react-diagrams-defaults/src/node/DefaultNodeWidget.tsx#L43

I haven't had time to look into that issue, there's probably some better css we can use there to accomplish the same effect.



