### PR TITLE
issue #407 update css to remove first-child unsafe warning

### DIFF
--- a/packages/react-diagrams-defaults/src/node/DefaultNodeWidget.tsx
+++ b/packages/react-diagrams-defaults/src/node/DefaultNodeWidget.tsx
@@ -40,7 +40,7 @@ namespace S {
 		display: flex;
 		flex-direction: column;
 
-		&:first-child {
+		&:first-of-type {
 			margin-right: 10px;
 		}
 


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Fix a warning that happens due to some css (:first-child unsafe)

## Why?
A clean console is a happy ocnsole.

## How?
Replacing first-child with first-of-type (as recommended by the warning) due to structure of the dom, the net-effect is the same. 

## Feel good image:
I messed up the template



