### PR TITLE
bugfix after deserialize link has no source or target port and code i…

### DIFF
--- a/packages/react-diagrams-routing/src/link/RightAngleLinkWidget.tsx
+++ b/packages/react-diagrams-routing/src/link/RightAngleLinkWidget.tsx
@@ -211,7 +211,9 @@ export class RightAngleLinkWidget extends React.Component<RightAngleLinkProps, R
 			this.props.link.setManuallyFirstAndLastPathsDirection(true, true);
 		}
 		// When new link is moving and not connected to target port move with middle point
-		else if (this.props.link.getTargetPort() === null) {
+		// TODO: @DanielLazarLDAPPS This will be better to update in DragNewLinkState 
+		//  in function fireMouseMoved to avoid calling this unexpectedly e.g. after Deserialize
+		else if (this.props.link.getTargetPort() === null && this.props.link.getSourcePort() !== null) {
 			points[1].setPosition(pointRight.getX() + (pointLeft.getX() - pointRight.getX())/2,
 				!hadToSwitch ? pointLeft.getY() : pointRight.getY());
 			points[2].setPosition(pointRight.getX() + (pointLeft.getX() - pointRight.getX())/2,
@@ -231,7 +233,6 @@ export class RightAngleLinkWidget extends React.Component<RightAngleLinkProps, R
 					else { points[i - 1].setPosition(points[i].getX(), points[i - 1].getY()) }
 				}
 			}
-
 		}
 
 		// If there is existing link which has two points add one


### PR DESCRIPTION
…n body of condition should not be called. This is quick fix. Better will be handle it in fireMouseMoved of DragNewLinkState

# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Hi @dylanvorster, There is still one case when links are broken after deserializing. This is the quick fix.

## Why?
Because links are still broken after deserializing.

## How?
 During deserialize, source and target port not exist so there is the condition for it.

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


