### PR TITLE
bugfix NodeModel should be apply a deep copy instead of shallow copy …

### DIFF
--- a/packages/react-canvas-core/src/core-models/BaseEntity.ts
+++ b/packages/react-canvas-core/src/core-models/BaseEntity.ts
@@ -60,7 +60,7 @@ export class BaseEntity<T extends BaseEntityGenerics = BaseEntityGenerics> exten
 		if (lookupTable[this.options.id]) {
 			return lookupTable[this.options.id];
 		}
-		let clone = _.clone(this);
+		let clone = _.cloneDeep(this);
 		clone.options = {
 			...this.options,
 			id: Toolkit.UID()


### PR DESCRIPTION
This is a fix for BaseEntity clone method. ( #436 )

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

Working on a project where custom model extends NodeModel with properties data arrays and object, applying a clone to copy those node will result to keep a reference on those properties and any changes will be apply to the original node and any other copy.

## Why?

This because clone is shallow copy. You should be using cloneDeep.

Check the Reference here: https://lodash.com/docs#cloneDeep

A shallow copy will only copy over data on each property of the object. So arrays and objects are passed by reference. A shallow copy is relatively fast. A deep copy on the other hand recursively goes down the tree, so objects and arrays are new instances. Deep copies are relatively slow, so be weary of using them unless needed.

## How?
 
When applying a copy of a node using clone.

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


