### PR TITLE
Fix: Also check canLinkToPort in DragDiagramItemsState

### DIFF
--- a/packages/react-diagrams-core/src/states/DragDiagramItemsState.ts
+++ b/packages/react-diagrams-core/src/states/DragDiagramItemsState.ts
@@ -23,9 +23,11 @@ export class DragDiagramItemsState extends MoveItemsState<DiagramEngine> {
 								if (link.getLastPoint() !== position.item) {
 									return;
 								}
-								link.setTargetPort(item);
-								item.reportPosition();
-								this.engine.repaintCanvas();
+								if (link.getSourcePort().canLinkToPort(item)) {
+									link.setTargetPort(item);
+									item.reportPosition();
+									this.engine.repaintCanvas();
+								}
 							}
 						});
 					}


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
There is a bug allowing to connect two Ports without check of `canLinkToPort`

## Why?
The `canLinkToPort` function was not called every time two ports get connected.
How to reproduce the error:
1. A link is not directly connected to another port but placed on the canvas first.
2. The endpoint is then later on connected to a port
3. The `canLinkToPort` function is **not** invoked and the link can be put to every port.

## How?
 If the link is directly connected to another port the `mouse-up` from `DragDiagramItemsState` is called.
But if the link is first placed on the canvas and later on connected to another port the `mouse-up` from `DragNewLinkState` is called.

## Feel good image:

(Add your own one below :])

I just like this gif :)
![I just like this gif](https://media.giphy.com/media/O8oPnvoMi31mw/giphy.gif)


