### PR TITLE
Fix #450 by exporting SmartLayerWidget from react-canvas-core

### DIFF
--- a/packages/react-canvas-core/index.ts
+++ b/packages/react-canvas-core/index.ts
@@ -21,6 +21,7 @@ export * from './src/entities/canvas/CanvasWidget';
 
 export * from './src/entities/layer/LayerModel';
 export * from './src/entities/layer/TransformLayerWidget';
+export * from './src/entities/layer/SmartLayerWidget';
 
 export * from './src/entities/selection/SelectionBoxLayerFactory';
 export * from './src/entities/selection/SelectionBoxWidget';


### PR DESCRIPTION
Fixes #450

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a water because you are awesome

## What?
Export the `SmartLayerWidget` from `react-canvas-core`.

## Why?
In the event that a developer would like to override or customize the `CanvasWidget` component. This PR allows developers to override the `CanvasWidget` without introducing new code to replicate behavior/components that have already been defined, since it exposes all the components used to build the `CanvasWidget`.

## How?
 Simply export the component in the `index.tsx` file.

## Feel good image:

(Add your own one below :])

![LOL](https://i.redd.it/17thm38r0yq31.jpg)


