### PR TITLE
Do not delete node if focused on an input

### DIFF
--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -300,6 +300,11 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 	}
 
 	onKeyUp(event) {
+		// Do not delete node if there is a focus on an input
+		if (document.activeElement !== document.body) {
+			return
+		}
+		
 		//delete all selected
 		if (this.props.deleteKeys.indexOf(event.keyCode) !== -1) {
 			_.forEach(this.props.diagramEngine.getDiagramModel().getSelectedItems(), element => {


### PR DESCRIPTION
# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [X] The PR Template has been filled out (see below)
- [X] Had a beer/coffee because you are awesome

## What?
Prevents deletion of a selected node if there is a focus on an input.

## Why?
While trying to delete text from an HTML input using backspace key when also focused on a node, even though the text input is focused, selected node deletion code gets triggered and deletes both the text in the text input and the selected nodes.


## How?
Checks if the active element equals to body element. If not, prevents deleting the selected nodes.
