### PR TITLE
Remove error when creating a new canvas without node

### DIFF
--- a/packages/react-diagrams-routing/src/link/PathFindingLinkFactory.tsx
+++ b/packages/react-diagrams-routing/src/link/PathFindingLinkFactory.tsx
@@ -195,25 +195,20 @@ export class PathFindingLinkFactory extends DefaultLinkFactory<PathFindingLinkMo
 			height: 0
 		}));
 
-		const canvas = this.engine.getCanvas() as HTMLDivElement;
-		const minX =
-			Math.floor(
-				Math.min(_.minBy(_.concat(allNodesCoords, allPortsCoords, allPointsCoords), item => item.x).x, 0) /
-					this.ROUTING_SCALING_FACTOR
-			) * this.ROUTING_SCALING_FACTOR;
-		const maxXElement = _.maxBy(_.concat(allNodesCoords, allPortsCoords, allPointsCoords), item => item.x + item.width);
-		const maxX = Math.max(maxXElement.x + maxXElement.width, canvas.offsetWidth);
+		const sumProps = (object, props) => _.reduce(props, (acc, prop) => acc + _.get(object, prop, 0), 0);
 
+		const canvas = this.engine.getCanvas() as HTMLDivElement;
+		const concatedCoords = _.concat(allNodesCoords, allPortsCoords, allPointsCoords);
+		const minX =
+			Math.floor(Math.min(_.get(_.minBy(concatedCoords, 'x'), 'x', 0), 0) / this.ROUTING_SCALING_FACTOR) *
+			this.ROUTING_SCALING_FACTOR;
+		const maxXElement = _.maxBy(concatedCoords, item => sumProps(item, ['x', 'width']));
+		const maxX = Math.max(sumProps(maxXElement, ['x', 'width']), canvas.offsetWidth);
+		const minYCoords = _.minBy(concatedCoords, 'y');
 		const minY =
-			Math.floor(
-				Math.min(_.minBy(_.concat(allNodesCoords, allPortsCoords, allPointsCoords), item => item.y).y, 0) /
-					this.ROUTING_SCALING_FACTOR
-			) * this.ROUTING_SCALING_FACTOR;
-		const maxYElement = _.maxBy(
-			_.concat(allNodesCoords, allPortsCoords, allPointsCoords),
-			item => item.y + item.height
-		);
-		const maxY = Math.max(maxYElement.y + maxYElement.height, canvas.offsetHeight);
+			Math.floor(Math.min(_.get(minYCoords, 'y', 0), 0) / this.ROUTING_SCALING_FACTOR) * this.ROUTING_SCALING_FACTOR;
+		const maxYElement = _.maxBy(concatedCoords, item => sumProps(item, ['y', 'height']));
+		const maxY = Math.max(sumProps(maxYElement, ['y', 'height']), canvas.offsetHeight);
 
 		return {
 			width: Math.ceil(Math.abs(minX) + maxX),


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Plain new diagram engine causes "Uncaught TypeError: Cannot read property 'x' of undefined"
https://github.com/projectstorm/react-diagrams/issues/433

## Why?
Get properties from undefined.

## How?
 I used lodash 'get' function for getting correct data or set default values.


