### PR TITLE
Export DeleteItemsAction and function to deregister the default DeleteItemsAction

### DIFF
--- a/packages/diagrams-demo-gallery/demos/demo-custom_delete_keys/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-custom_delete_keys/index.tsx
@@ -4,7 +4,8 @@ import { CanvasWidget, DeleteItemsAction } from '@projectstorm/react-canvas-core
 import { DemoCanvasWidget } from '../helpers/DemoCanvasWidget';
 
 export default () => {
-	const engine = createEngine();
+	// create an engine without registering DeleteItemsAction
+	const engine = createEngine({ registerDefaultDeleteItemsAction: false });
 	const model = new DiagramModel();
 
 	const node1 = new DefaultNodeModel('Node 1', 'rgb(0,192,255)');
@@ -19,9 +20,7 @@ export default () => {
 
 	engine.setModel(model);
 
-	//deregister the default DeleteItemsAction
-	engine.deregisterDefaultDeleteItemsAction();
-	//add another DeleteItemsAction with custom keyCodes (in this case, only Delete key)
+	// register an DeleteItemsAction with custom keyCodes (in this case, only Delete key)
 	this.eventBus.registerAction(new DeleteItemsAction({ keyCodes: [46] }));
 
 	return (

--- a/packages/diagrams-demo-gallery/demos/demo-custom_delete_keys/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-custom_delete_keys/index.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import createEngine, { DiagramModel, DefaultNodeModel } from '@projectstorm/react-diagrams';
+import { CanvasWidget, DeleteItemsAction } from '@projectstorm/react-canvas-core';
+import { DemoCanvasWidget } from '../helpers/DemoCanvasWidget';
+
+export default () => {
+	const engine = createEngine();
+	const model = new DiagramModel();
+
+	const node1 = new DefaultNodeModel('Node 1', 'rgb(0,192,255)');
+	node1.addOutPort('Out');
+	node1.setPosition(100, 100);
+
+	const node2 = new DefaultNodeModel('Node 2', 'rgb(192,255,0)');
+	node2.addInPort('In');
+	node2.setPosition(400, 100);
+
+	model.addAll(node1, node2);
+
+	engine.setModel(model);
+
+	//deregister the default DeleteItemsAction
+	engine.deregisterDefaultDeleteItemsAction();
+	//add another DeleteItemsAction with custom keyCodes (in this case, only Delete key)
+	this.eventBus.registerAction(new DeleteItemsAction({ keyCodes: [46] }));
+
+	return (
+		<DemoCanvasWidget>
+			<CanvasWidget engine={engine} />
+		</DemoCanvasWidget>
+	);
+};

--- a/packages/diagrams-demo-gallery/demos/demo-custom_delete_keys/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-custom_delete_keys/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import createEngine, { DiagramModel, DefaultNodeModel } from '@projectstorm/react-diagrams';
+import createEngine, { DiagramModel, DefaultNodeModel, DefaultLinkModel } from '@projectstorm/react-diagrams';
 import { CanvasWidget, DeleteItemsAction } from '@projectstorm/react-canvas-core';
 import { DemoCanvasWidget } from '../helpers/DemoCanvasWidget';
 
@@ -8,20 +8,24 @@ export default () => {
 	const engine = createEngine({ registerDefaultDeleteItemsAction: false });
 	const model = new DiagramModel();
 
-	const node1 = new DefaultNodeModel('Node 1', 'rgb(0,192,255)');
-	node1.addOutPort('Out');
+	const node1 = new DefaultNodeModel({ name: 'Node 1', color: 'rgb(0,192,255)' });
 	node1.setPosition(100, 100);
+	const port1 = node1.addOutPort('Out');
 
 	const node2 = new DefaultNodeModel('Node 2', 'rgb(192,255,0)');
-	node2.addInPort('In');
+	const port2 = node2.addInPort('In');
 	node2.setPosition(400, 100);
 
-	model.addAll(node1, node2);
+	const link1 = port1.link<DefaultLinkModel>(port2);
+	link1.getOptions().testName = 'Test';
+	link1.addLabel('Hello World!');
+
+	model.addAll(node1, node2, link1);
 
 	engine.setModel(model);
 
 	// register an DeleteItemsAction with custom keyCodes (in this case, only Delete key)
-	this.eventBus.registerAction(new DeleteItemsAction({ keyCodes: [46] }));
+	engine.getActionEventBus().registerAction(new DeleteItemsAction({ keyCodes: [46] }));
 
 	return (
 		<DemoCanvasWidget>

--- a/packages/diagrams-demo-gallery/index.tsx
+++ b/packages/diagrams-demo-gallery/index.tsx
@@ -34,6 +34,7 @@ import demo_zoom from './demos/demo-zoom-to-fit';
 import demo_labels from './demos/demo-labelled-links';
 import demo_dynamic_ports from './demos/demo-dynamic-ports';
 import demo_alternative_linking from './demos/demo-alternative-linking';
+import demo_custom_delete_keys from './demos/demo-custom_delete_keys';
 
 storiesOf('Simple Usage', module)
 	.add('Simple example', demo_simple)
@@ -60,7 +61,8 @@ storiesOf('Advanced Techniques', module)
 	.add('Drag and drop', demo_adv_dnd)
 	.add('Smart routing', demo_smart_routing)
 	.add('Right angles routing', demo_right_angles_routing)
-	.add('Linking by clicking instead of dragging', demo_alternative_linking);
+	.add('Linking by clicking instead of dragging', demo_alternative_linking)
+	.add('Setting custom delete keys', demo_custom_delete_keys);
 
 import demo_cust_nodes from './demos/demo-custom-node1';
 import demo_cust_links from './demos/demo-custom-link1';

--- a/packages/react-canvas-core/index.ts
+++ b/packages/react-canvas-core/index.ts
@@ -38,3 +38,6 @@ export * from './src/states/DragCanvasState';
 export * from './src/states/SelectingState';
 export * from './src/states/SelectionBoxState';
 export * from './src/states/MoveItemsState';
+
+export * from './src/actions/DeleteItemsAction';
+export * from './src/actions/ZoomCanvasAction';

--- a/packages/react-canvas-core/src/CanvasEngine.ts
+++ b/packages/react-canvas-core/src/CanvasEngine.ts
@@ -26,17 +26,16 @@ export interface CanvasEngineOptions {
 
 export class CanvasEngine<
 	L extends CanvasEngineListener = CanvasEngineListener,
-	M extends CanvasModel = CanvasModel,
-	O extends CanvasEngineOptions = CanvasEngineOptions
+	M extends CanvasModel = CanvasModel
 > extends BaseObserver<L> {
 	protected model: M;
 	protected layerFactories: FactoryBank<AbstractReactFactory<LayerModel>>;
 	protected canvas: HTMLDivElement;
 	protected eventBus: ActionEventBus;
 	protected stateMachine: StateMachine;
-	protected options: O;
+	protected options: CanvasEngineOptions;
 
-	constructor(options:O = {}) {
+	constructor(options: CanvasEngineOptions = {}) {
 		super();
 		this.model = null;
 		this.eventBus = new ActionEventBus(this);

--- a/packages/react-canvas-core/src/CanvasEngine.ts
+++ b/packages/react-canvas-core/src/CanvasEngine.ts
@@ -36,10 +36,7 @@ export class CanvasEngine<
 	protected stateMachine: StateMachine;
 	protected options: O;
 
-	deregisterDefaultDeleteItemsAction: () => void;
-	deregisterDefaultZoomCanvasAction: () => void;
-
-	constructor(options: CanvasEngineOptions = {}) {
+	constructor(options:O = {}) {
 		super();
 		this.model = null;
 		this.eventBus = new ActionEventBus(this);

--- a/packages/react-canvas-core/src/CanvasEngine.ts
+++ b/packages/react-canvas-core/src/CanvasEngine.ts
@@ -19,28 +19,44 @@ export interface CanvasEngineListener extends BaseListener {
 	rendered?(): void;
 }
 
+export interface CanvasEngineOptions {
+	registerDefaultDeleteItemsAction?: boolean;
+	registerDefaultZoomCanvasAction?: boolean;
+}
+
 export class CanvasEngine<
 	L extends CanvasEngineListener = CanvasEngineListener,
-	M extends CanvasModel = CanvasModel
+	M extends CanvasModel = CanvasModel,
+	O extends CanvasEngineOptions = CanvasEngineOptions
 > extends BaseObserver<L> {
 	protected model: M;
 	protected layerFactories: FactoryBank<AbstractReactFactory<LayerModel>>;
 	protected canvas: HTMLDivElement;
 	protected eventBus: ActionEventBus;
 	protected stateMachine: StateMachine;
+	protected options: O;
 
 	deregisterDefaultDeleteItemsAction: () => void;
 	deregisterDefaultZoomCanvasAction: () => void;
 
-	constructor() {
+	constructor(options: CanvasEngineOptions = {}) {
 		super();
 		this.model = null;
 		this.eventBus = new ActionEventBus(this);
 		this.stateMachine = new StateMachine(this);
 		this.layerFactories = new FactoryBank();
 		this.registerFactoryBank(this.layerFactories);
-		this.deregisterDefaultZoomCanvasAction = this.eventBus.registerAction(new ZoomCanvasAction());
-		this.deregisterDefaultDeleteItemsAction = this.eventBus.registerAction(new DeleteItemsAction());
+		this.options = {
+			registerDefaultDeleteItemsAction: true,
+			registerDefaultZoomCanvasAction: true,
+			...options
+		};
+		if (this.options.registerDefaultZoomCanvasAction === true) {
+			this.eventBus.registerAction(new ZoomCanvasAction());
+		}
+		if (this.options.registerDefaultDeleteItemsAction === true) {
+			this.eventBus.registerAction(new DeleteItemsAction());
+		}
 	}
 
 	getStateMachine() {

--- a/packages/react-canvas-core/src/CanvasEngine.ts
+++ b/packages/react-canvas-core/src/CanvasEngine.ts
@@ -29,6 +29,9 @@ export class CanvasEngine<
 	protected eventBus: ActionEventBus;
 	protected stateMachine: StateMachine;
 
+	deregisterDefaultDeleteItemsAction: () => void;
+	deregisterDefaultZoomCanvasAction: () => void;
+
 	constructor() {
 		super();
 		this.model = null;
@@ -36,8 +39,8 @@ export class CanvasEngine<
 		this.stateMachine = new StateMachine(this);
 		this.layerFactories = new FactoryBank();
 		this.registerFactoryBank(this.layerFactories);
-		this.eventBus.registerAction(new ZoomCanvasAction());
-		this.eventBus.registerAction(new DeleteItemsAction());
+		this.deregisterDefaultZoomCanvasAction = this.eventBus.registerAction(new ZoomCanvasAction());
+		this.deregisterDefaultDeleteItemsAction = this.eventBus.registerAction(new DeleteItemsAction());
 	}
 
 	getStateMachine() {

--- a/packages/react-diagrams-core/src/DiagramEngine.ts
+++ b/packages/react-diagrams-core/src/DiagramEngine.ts
@@ -12,7 +12,7 @@ import {
 	FactoryBank,
 	Toolkit
 } from '@projectstorm/react-canvas-core';
-import { CanvasEngineListener } from '@projectstorm/react-canvas-core';
+import { CanvasEngineListener, CanvasEngineOptions } from '@projectstorm/react-canvas-core';
 import { DiagramModel } from './models/DiagramModel';
 
 /**
@@ -26,8 +26,8 @@ export class DiagramEngine extends CanvasEngine<CanvasEngineListener, DiagramMod
 
 	maxNumberPointsPerLink: number;
 
-	constructor() {
-		super();
+	constructor(options: CanvasEngineOptions = {}) {
+		super(options);
 		this.maxNumberPointsPerLink = 1000;
 
 		// create banks for the different factory types

--- a/packages/react-diagrams/index.ts
+++ b/packages/react-diagrams/index.ts
@@ -11,7 +11,7 @@ import {
 	DefaultPortFactory
 } from '@projectstorm/react-diagrams-defaults';
 import { PathFindingLinkFactory } from '@projectstorm/react-diagrams-routing';
-import { SelectionBoxLayerFactory } from '@projectstorm/react-canvas-core';
+import { SelectionBoxLayerFactory, CanvasEngineOptions } from '@projectstorm/react-canvas-core';
 
 export * from '@projectstorm/react-diagrams-core';
 export * from '@projectstorm/react-diagrams-defaults';
@@ -20,8 +20,8 @@ export * from '@projectstorm/react-diagrams-routing';
 /**
  * Construct an engine with the defaults installed
  */
-export default (): DiagramEngine => {
-	const engine = new DiagramEngine();
+export default (options: CanvasEngineOptions = {}): DiagramEngine => {
+	const engine = new DiagramEngine(options);
 
 	// register model factories
 	engine.getLayerFactories().registerFactory(new NodeLayerFactory());


### PR DESCRIPTION
DeleteItemsAction and ZoomCanvasAction are now exported;
Now there is 2 functions to deregister the default ZoomCanvas and DeleteItems actions;
A exemple with how to deregister and register another DeleteItemsAction

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Export DeleteItemsAction and ZoomCanvasAction, and create a function do deregister the default ones.
## Why?
Becase someday you may want to change the default keys that delete Nodes and Links :)
like #414 and #463 

## How?
DeleteItemsAction and ZoomCanvasAction are now exported from react-canvas-core;
Now there is 2 functions to deregister the default ZoomCanvas and DeleteItems actions in the CanvasEngine;
And now there's an exemple with how to deregister and register another DeleteItemsAction
 

## Feel good image:
![LOL](https://d2u3dcdbebyaiu.cloudfront.net/uploads/atch_img/688/0ee80bc413f372c9c6ed32136031ac58.jpeg)


