### PR TITLE
link far end aligns with the mouse pointer position

### DIFF
--- a/packages/diagrams-demo-gallery/demos/demo-dagre/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-dagre/index.tsx
@@ -41,9 +41,9 @@ class DemoWidget extends React.Component<{ model: DiagramModel; engine: DiagramE
 		this.engine = new DagreEngine({
 			graph: {
 				rankdir: 'RL',
-				ranker: 'longest-path', 
-				marginx:25,
-				marginy:25
+				ranker: 'longest-path',
+				marginx: 25,
+				marginy: 25
 			},
 			includeLinks: true
 		});

--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -9,6 +9,7 @@ import { PortModel } from '../entities/port/PortModel';
 import { MouseEvent } from 'react';
 import { LinkModel } from '../entities/link/LinkModel';
 import { DiagramEngine } from '../DiagramEngine';
+import { Point } from '@projectstorm/geometry';
 
 export interface DragNewLinkStateOptions {
 	/**
@@ -26,6 +27,9 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 	port: PortModel;
 	link: LinkModel;
 	config: DragNewLinkStateOptions;
+
+	// will contain the mouse x,y position when it starts dragging a new link
+	startingPoint: Point;
 
 	constructor(options: DragNewLinkStateOptions = {}) {
 		super({
@@ -56,6 +60,9 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 					this.link.setSourcePort(this.port);
 					this.engine.getModel().addLink(this.link);
 					this.port.reportPosition();
+
+					// save the mouse position for further precision in calculating the link's far-end point
+					this.startingPoint = new Point(event.event.clientX, event.event.clientY);
 				}
 			})
 		);
@@ -79,14 +86,23 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 						this.link.remove();
 						this.engine.repaintCanvas();
 					}
+
+					// clear the starting point
+					this.startingPoint = undefined;
 				}
 			})
 		);
 	}
-
+	/**
+	 * When the mouse moves calculates the link's far-end point position.
+	 * In order to be as precise as possible the mouse startingPoint is taken into account.
+	 */
 	fireMouseMoved(event: AbstractDisplacementStateEvent): any {
 		const pos = this.port.getPosition();
-		this.link.getLastPoint().setPosition(pos.x + event.virtualDisplacementX, pos.y + event.virtualDisplacementY);
+		const linkNextPosX = pos.x + (this.startingPoint.x - pos.x) + event.virtualDisplacementX;
+		const linkNextPosY = pos.y + (this.startingPoint.y - pos.y) + event.virtualDisplacementY;
+
+		this.link.getLastPoint().setPosition(linkNextPosX, linkNextPosY);
 		this.engine.repaintCanvas();
 	}
 }

--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -86,13 +86,13 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 	}
 
 	/**
-	 * When the mouse moves calculates the link's far-end point position.
-	 * In order to be as precise as possible the mouse initialX & initialY are taken into account.
+	 * Calculates the link's far-end point position on mouse move.
+	 * In order to be as precise as possible the mouse initialXRelative & initialYRelative are taken into account.
 	 */
 	fireMouseMoved(event: AbstractDisplacementStateEvent): any {
 		const pos = this.port.getPosition();
-		const linkNextPosX = pos.x + (this.initialX - pos.x) + event.virtualDisplacementX;
-		const linkNextPosY = pos.y + (this.initialY - pos.y) + event.virtualDisplacementY;
+		const linkNextPosX = pos.x + (this.initialXRelative - pos.x) + event.virtualDisplacementX;
+		const linkNextPosY = pos.y + (this.initialYRelative - pos.y) + event.virtualDisplacementY;
 
 		this.link.getLastPoint().setPosition(linkNextPosX, linkNextPosY);
 		this.engine.repaintCanvas();

--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -28,9 +28,6 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 	link: LinkModel;
 	config: DragNewLinkStateOptions;
 
-	// will contain the mouse x,y position when it starts dragging a new link
-	startingPoint: Point;
-
 	constructor(options: DragNewLinkStateOptions = {}) {
 		super({
 			name: 'drag-new-link'
@@ -60,9 +57,6 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 					this.link.setSourcePort(this.port);
 					this.engine.getModel().addLink(this.link);
 					this.port.reportPosition();
-
-					// save the mouse position for further precision in calculating the link's far-end point
-					this.startingPoint = new Point(event.event.clientX, event.event.clientY);
 				}
 			})
 		);
@@ -86,21 +80,19 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 						this.link.remove();
 						this.engine.repaintCanvas();
 					}
-
-					// clear the starting point
-					this.startingPoint = undefined;
 				}
 			})
 		);
 	}
+
 	/**
 	 * When the mouse moves calculates the link's far-end point position.
-	 * In order to be as precise as possible the mouse startingPoint is taken into account.
+	 * In order to be as precise as possible the mouse initialX & initialY are taken into account.
 	 */
 	fireMouseMoved(event: AbstractDisplacementStateEvent): any {
 		const pos = this.port.getPosition();
-		const linkNextPosX = pos.x + (this.startingPoint.x - pos.x) + event.virtualDisplacementX;
-		const linkNextPosY = pos.y + (this.startingPoint.y - pos.y) + event.virtualDisplacementY;
+		const linkNextPosX = pos.x + (this.initialX - pos.x) + event.virtualDisplacementX;
+		const linkNextPosY = pos.y + (this.initialY - pos.y) + event.virtualDisplacementY;
 
 		this.link.getLastPoint().setPosition(linkNextPosX, linkNextPosY);
 		this.engine.repaintCanvas();

--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -87,14 +87,17 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 
 	/**
 	 * Calculates the link's far-end point position on mouse move.
-	 * In order to be as precise as possible the mouse initialXRelative & initialYRelative are taken into account.
+	 * In order to be as precise as possible the mouse initialXRelative & initialYRelative are taken into account as well
+	 * as the possible engine offset
 	 */
 	fireMouseMoved(event: AbstractDisplacementStateEvent): any {
-		const pos = this.port.getPosition();
-		const linkNextPosX = pos.x + (this.initialXRelative - pos.x) + event.virtualDisplacementX;
-		const linkNextPosY = pos.y + (this.initialYRelative - pos.y) + event.virtualDisplacementY;
+		const portPos = this.port.getPosition();
+		const engineOffsetX = this.engine.getModel().getOffsetX();
+		const engineOffsetY = this.engine.getModel().getOffsetY();
+		const linkNextX = portPos.x - engineOffsetX + (this.initialXRelative - portPos.x) + event.virtualDisplacementX;
+		const linkNextY = portPos.y - engineOffsetY + (this.initialYRelative - portPos.y) + event.virtualDisplacementY;
 
-		this.link.getLastPoint().setPosition(linkNextPosX, linkNextPosY);
+		this.link.getLastPoint().setPosition(linkNextX, linkNextY);
 		this.engine.repaintCanvas();
 	}
 }

--- a/packages/react-diagrams-routing/src/dagre/DagreEngine.ts
+++ b/packages/react-diagrams-routing/src/dagre/DagreEngine.ts
@@ -59,7 +59,7 @@ export class DagreEngine {
 
 		g.nodes().forEach(v => {
 			const node = g.node(v);
-			model.getNode(v).setPosition(node.x - (node.width / 2), node.y - (node.height / 2));
+			model.getNode(v).setPosition(node.x - node.width / 2, node.y - node.height / 2);
 		});
 
 		// also include links?

--- a/packages/react-diagrams-routing/src/link/RightAngleLinkModel.ts
+++ b/packages/react-diagrams-routing/src/link/RightAngleLinkModel.ts
@@ -19,11 +19,14 @@ export class RightAngleLinkModel extends DefaultLinkModel {
 
 	setFirstAndLastPathsDirection() {
 		let points = this.getPoints();
-		for (let i = 1; i < points.length; i+= points.length - 2) {
+		for (let i = 1; i < points.length; i += points.length - 2) {
 			let dx = Math.abs(points[i].getX() - points[i - 1].getX());
 			let dy = Math.abs(points[i].getY() - points[i - 1].getY());
-			if (i - 1 === 0) { this._firstPathXdirection = dx > dy }
-			else { this._lastPathXdirection = dx > dy }
+			if (i - 1 === 0) {
+				this._firstPathXdirection = dx > dy;
+			} else {
+				this._lastPathXdirection = dx > dy;
+			}
 		}
 	}
 
@@ -62,4 +65,3 @@ export class RightAngleLinkModel extends DefaultLinkModel {
 		this.fireEvent({ color }, 'colorChanged');
 	}
 }
-

--- a/packages/react-diagrams-routing/src/link/RightAngleLinkWidget.tsx
+++ b/packages/react-diagrams-routing/src/link/RightAngleLinkWidget.tsx
@@ -203,34 +203,47 @@ export class RightAngleLinkWidget extends React.Component<RightAngleLinkProps, R
 		// When new link add one middle point to get everywhere 90° angle
 		if (this.props.link.getTargetPort() === null && points.length === 2) {
 			[...Array(2)].forEach(item => {
-				this.props.link.addPoint(new PointModel({
-					link: this.props.link,
-					position: new Point(pointLeft.getX(), pointRight.getY())
-				}), 1);
+				this.props.link.addPoint(
+					new PointModel({
+						link: this.props.link,
+						position: new Point(pointLeft.getX(), pointRight.getY())
+					}),
+					1
+				);
 			});
 			this.props.link.setManuallyFirstAndLastPathsDirection(true, true);
 		}
 		// When new link is moving and not connected to target port move with middle point
-		// TODO: @DanielLazarLDAPPS This will be better to update in DragNewLinkState 
+		// TODO: @DanielLazarLDAPPS This will be better to update in DragNewLinkState
 		//  in function fireMouseMoved to avoid calling this unexpectedly e.g. after Deserialize
 		else if (this.props.link.getTargetPort() === null && this.props.link.getSourcePort() !== null) {
-			points[1].setPosition(pointRight.getX() + (pointLeft.getX() - pointRight.getX())/2,
-				!hadToSwitch ? pointLeft.getY() : pointRight.getY());
-			points[2].setPosition(pointRight.getX() + (pointLeft.getX() - pointRight.getX())/2,
-				!hadToSwitch ? pointRight.getY() : pointLeft.getY());
+			points[1].setPosition(
+				pointRight.getX() + (pointLeft.getX() - pointRight.getX()) / 2,
+				!hadToSwitch ? pointLeft.getY() : pointRight.getY()
+			);
+			points[2].setPosition(
+				pointRight.getX() + (pointLeft.getX() - pointRight.getX()) / 2,
+				!hadToSwitch ? pointRight.getY() : pointLeft.getY()
+			);
 		}
 		// Render was called but link is not moved but user.
 		// Node is moved and in this case fix coordinates to get 90° angle.
 		// For loop just for first and last path
 		else if (!this.state.canDrag && points.length > 2) {
 			// Those points and its position only will be moved
-			for (let i = 1; i < points.length; i+= points.length - 2) {
+			for (let i = 1; i < points.length; i += points.length - 2) {
 				if (i - 1 === 0) {
-					if (this.props.link.getFirstPathXdirection()) { points[i].setPosition(points[i].getX(), points[i - 1].getY()) }
-					else { points[i].setPosition(points[i - 1].getX(), points[i].getY()) }
+					if (this.props.link.getFirstPathXdirection()) {
+						points[i].setPosition(points[i].getX(), points[i - 1].getY());
+					} else {
+						points[i].setPosition(points[i - 1].getX(), points[i].getY());
+					}
 				} else {
-					if (this.props.link.getLastPathXdirection()) { points[i - 1].setPosition(points[i - 1].getX(), points[i].getY()) }
-					else { points[i - 1].setPosition(points[i].getX(), points[i - 1].getY()) }
+					if (this.props.link.getLastPathXdirection()) {
+						points[i - 1].setPosition(points[i - 1].getX(), points[i].getY());
+					} else {
+						points[i - 1].setPosition(points[i].getX(), points[i - 1].getY());
+					}
 				}
 			}
 		}
@@ -242,7 +255,8 @@ export class RightAngleLinkWidget extends React.Component<RightAngleLinkProps, R
 				new PointModel({
 					link: this.props.link,
 					position: new Point(pointLeft.getX(), pointRight.getY())
-				}));
+				})
+			);
 		}
 
 		for (let j = 0; j < points.length - 1; j++) {


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
The `DragNewLinkState.fireMouseMoved` method was not taking into account the click starting position when dragging a new link, it just assumes it's the same point (x,y) of the link port. Sometimes, especially with big ports, it causes a slight mismatch between the link far end point and the mouse position as reported in the issue #467 

<img src="https://i.postimg.cc/bwnwCnmS/Screenshot-2019-11-17-at-23-47-39.png">


## How?

I saved the mouse starting position within the `DragNewLinkState` class itself. 

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


