### PR TITLE
Fixing #470

### DIFF
--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -92,10 +92,13 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 	 */
 	fireMouseMoved(event: AbstractDisplacementStateEvent): any {
 		const portPos = this.port.getPosition();
-		const engineOffsetX = this.engine.getModel().getOffsetX();
-		const engineOffsetY = this.engine.getModel().getOffsetY();
-		const linkNextX = portPos.x - engineOffsetX + (this.initialXRelative - portPos.x) + event.virtualDisplacementX;
-		const linkNextY = portPos.y - engineOffsetY + (this.initialYRelative - portPos.y) + event.virtualDisplacementY;
+		const zoomLevelPercentage = this.engine.getModel().getZoomLevel() / 100;
+		const engineOffsetX = this.engine.getModel().getOffsetX() / zoomLevelPercentage;
+		const engineOffsetY = this.engine.getModel().getOffsetY() / zoomLevelPercentage;
+		const initialXRelative = this.initialXRelative / zoomLevelPercentage;
+		const initialYRelative = this.initialYRelative / zoomLevelPercentage;
+		const linkNextX = portPos.x - engineOffsetX + (initialXRelative - portPos.x) + event.virtualDisplacementX;
+		const linkNextY = portPos.y - engineOffsetY + (initialYRelative - portPos.y) + event.virtualDisplacementY;
 
 		this.link.getLastPoint().setPosition(linkNextX, linkNextY);
 		this.engine.repaintCanvas();


### PR DESCRIPTION
After the #469 PR, a bug when the zoom level is != from 1 make the link go far the mouse. Now it's considering the zoom level in the calculation

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
A bug introduced with #469 that doesn't take zoom level into account. It's figured out by #470 

## Why?
We need to take zoom level into account

## How?
Consider zoom level in account

## Feel good image:
![ha](https://user-images.githubusercontent.com/22898471/69272229-10610000-0bb5-11ea-9443-ba83b0f813dd.jpeg)


