### PR TITLE
Clicking on a source port causes a nonsense link segment, fixing #481

### DIFF
--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -9,7 +9,6 @@ import { PortModel } from '../entities/port/PortModel';
 import { MouseEvent } from 'react';
 import { LinkModel } from '../entities/link/LinkModel';
 import { DiagramEngine } from '../DiagramEngine';
-import { Point } from '@projectstorm/geometry';
 
 export interface DragNewLinkStateOptions {
 	/**
@@ -29,14 +28,14 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 	config: DragNewLinkStateOptions;
 
 	constructor(options: DragNewLinkStateOptions = {}) {
-		super({
-			name: 'drag-new-link'
-		});
+		super({ name: 'drag-new-link' });
+
 		this.config = {
 			allowLooseLinks: true,
 			allowLinksFromLockedPorts: false,
 			...options
 		};
+
 		this.registerAction(
 			new Action({
 				type: InputType.MOUSE_DOWN,
@@ -60,6 +59,7 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 				}
 			})
 		);
+
 		this.registerAction(
 			new Action({
 				type: InputType.MOUSE_UP,

--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -76,12 +76,27 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 						}
 					}
 
-					if (!this.config.allowLooseLinks) {
+					if (this.isNearbySourcePort(event.event) || !this.config.allowLooseLinks) {
 						this.link.remove();
 						this.engine.repaintCanvas();
 					}
 				}
 			})
+		);
+	}
+
+	/**
+	 * Checks whether the mouse event appears to happen in proximity of the link's source port
+	 * @param event
+	 */
+	isNearbySourcePort({ clientX, clientY }: MouseEvent): boolean {
+		const sourcePort = this.link.getSourcePort();
+		const sourcePortPosition = this.link.getSourcePort().getPosition();
+
+		return (
+			clientX >= sourcePortPosition.x &&
+			clientX <= sourcePortPosition.x + sourcePort.width &&
+			(clientY >= sourcePortPosition.y && clientY <= sourcePortPosition.y + sourcePort.height)
 		);
 	}
 


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Fixing the #481  

## Why?
Clicking on a source port without dragging a new link should not cause anything also should not be possible to link a segment to it own source port (or perhaps this should be a flag within its own model or something)

## How?
By comparing the source port position and the click position 

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


