### PR TITLE
Allow CanvasEngine to possibly have debouncing options for smooth animations 

### DIFF
--- a/packages/diagrams-demo-gallery/demos/demo-animation/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-animation/index.tsx
@@ -5,7 +5,6 @@ import { DemoWorkspaceWidget } from '../helpers/DemoWorkspaceWidget';
 import { CanvasWidget } from '@projectstorm/react-canvas-core';
 import { DemoCanvasWidget } from '../helpers/DemoCanvasWidget';
 
-
 /**
  * Tests the grid size
  */

--- a/packages/diagrams-demo-gallery/demos/demo-animation/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-animation/index.tsx
@@ -27,7 +27,7 @@ class NodeDelayedPosition extends React.Component<any, any> {
 
 export default () => {
 	//1) setup the diagram engine
-	var engine = createEngine({ repaintDebounce: true, repaintDebounceMs: 12 });
+	var engine = createEngine({ repaintDebounceMs: 12 });
 
 	//2) setup the diagram model
 	var model = new DiagramModel();

--- a/packages/diagrams-demo-gallery/demos/demo-animation/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-animation/index.tsx
@@ -1,10 +1,10 @@
-import createEngine, { DiagramModel, DefaultNodeModel, NodeModel } from '@projectstorm/react-diagrams';
+import createEngine, { DiagramModel, DefaultNodeModel } from '@projectstorm/react-diagrams';
 import * as React from 'react';
-import * as _ from 'lodash';
-import { DemoButton, DemoWorkspaceWidget } from '../helpers/DemoWorkspaceWidget';
+import gsap from 'gsap';
+import { DemoWorkspaceWidget } from '../helpers/DemoWorkspaceWidget';
 import { CanvasWidget } from '@projectstorm/react-canvas-core';
 import { DemoCanvasWidget } from '../helpers/DemoCanvasWidget';
-import gsap from 'gsap';
+
 
 /**
  * Tests the grid size
@@ -28,7 +28,7 @@ class NodeDelayedPosition extends React.Component<any, any> {
 
 export default () => {
 	//1) setup the diagram engine
-	var engine = createEngine();
+	var engine = createEngine({ repaintDebounce: true, repaintDebounceMs: 12 });
 
 	//2) setup the diagram model
 	var model = new DiagramModel();

--- a/packages/diagrams-demo-gallery/package-lock.json
+++ b/packages/diagrams-demo-gallery/package-lock.json
@@ -1,0 +1,13 @@
+{
+	"name": "@projectstorm/react-diagrams-gallery",
+	"version": "6.0.1-beta.6",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"gsap": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/gsap/-/gsap-3.0.1.tgz",
+			"integrity": "sha512-9nzEBF7Ss9Ogyw6oEOXZxxVYH8WNRA/nHmIp3DrPOTKmlLxX9MN2ovSoH9TApA+rucBgp9veCedujp5oSQRvZw=="
+		}
+	}
+}

--- a/packages/react-canvas-core/src/CanvasEngine.ts
+++ b/packages/react-canvas-core/src/CanvasEngine.ts
@@ -1,3 +1,4 @@
+import { debounce } from 'lodash';
 import { CanvasModel } from './entities/canvas/CanvasModel';
 import { FactoryBank } from './core/FactoryBank';
 import { AbstractReactFactory } from './core/AbstractReactFactory';
@@ -24,10 +25,8 @@ export interface CanvasEngineOptions {
 	registerDefaultZoomCanvasAction?: boolean;
 }
 
-export class CanvasEngine<
-	L extends CanvasEngineListener = CanvasEngineListener,
-	M extends CanvasModel = CanvasModel
-> extends BaseObserver<L> {
+export class CanvasEngine<L extends CanvasEngineListener = CanvasEngineListener,
+	M extends CanvasModel = CanvasModel> extends BaseObserver<L> {
 	protected model: M;
 	protected layerFactories: FactoryBank<AbstractReactFactory<LayerModel>>;
 	protected canvas: HTMLDivElement;
@@ -114,13 +113,13 @@ export class CanvasEngine<
 	repaintCanvas(promise: true): Promise<any>;
 	repaintCanvas(): void;
 	repaintCanvas(promise?): Promise<any> | void {
-		const repaint = () => {
+		const repaint = debounce(() => {
 			this.iterateListeners(listener => {
 				if (listener.repaintCanvas) {
 					listener.repaintCanvas();
 				}
 			});
-		};
+		}, 60);
 
 		if (promise) {
 			return new Promise(resolve => {

--- a/packages/react-canvas-core/src/CanvasEngine.ts
+++ b/packages/react-canvas-core/src/CanvasEngine.ts
@@ -32,8 +32,10 @@ export interface CanvasEngineOptions {
 	repaintDebounceMs?: number;
 }
 
-export class CanvasEngine<L extends CanvasEngineListener = CanvasEngineListener,
-	M extends CanvasModel = CanvasModel> extends BaseObserver<L> {
+export class CanvasEngine<
+	L extends CanvasEngineListener = CanvasEngineListener,
+	M extends CanvasModel = CanvasModel
+> extends BaseObserver<L> {
 	protected model: M;
 	protected layerFactories: FactoryBank<AbstractReactFactory<LayerModel>>;
 	protected canvas: HTMLDivElement;

--- a/packages/react-canvas-core/src/CanvasEngine.ts
+++ b/packages/react-canvas-core/src/CanvasEngine.ts
@@ -27,15 +27,10 @@ export interface CanvasEngineOptions {
 	registerDefaultDeleteItemsAction?: boolean;
 	registerDefaultZoomCanvasAction?: boolean;
 	/**
-	 * If set to true debounce the `repaintCanvas` method
+	 * Defines the debounce wait time in milliseconds if > 0
 	 */
-	repaintDebounce?: boolean
-	/**
-	 * Defines the debounce wait time in milliseconds
-	 */
-	repaintDebounceMs?: number,
+	repaintDebounceMs?: number;
 }
-
 
 export class CanvasEngine<L extends CanvasEngineListener = CanvasEngineListener,
 	M extends CanvasModel = CanvasModel> extends BaseObserver<L> {
@@ -60,7 +55,6 @@ export class CanvasEngine<L extends CanvasEngineListener = CanvasEngineListener,
 		this.options = {
 			registerDefaultDeleteItemsAction: true,
 			registerDefaultZoomCanvasAction: true,
-			repaintDebounce: false,
 			repaintDebounceMs: 0,
 			...options
 		};
@@ -131,7 +125,7 @@ export class CanvasEngine<L extends CanvasEngineListener = CanvasEngineListener,
 	repaintCanvas(promise: true): Promise<any>;
 	repaintCanvas(): void;
 	repaintCanvas(promise?): Promise<any> | void {
-		const { repaintDebounce, repaintDebounceMs } = this.options;
+		const { repaintDebounceMs } = this.options;
 
 		/**
 		 * The actual repaint function
@@ -144,8 +138,12 @@ export class CanvasEngine<L extends CanvasEngineListener = CanvasEngineListener,
 			});
 		};
 
-		// if repaintDebounce is set to true, debounce the 'repaint' function by the milliseconds defined by repaintDebounceMs
-		const repaintFn = repaintDebounce ? debounce(repaint, repaintDebounceMs) : repaint;
+		// if the `repaintDebounceMs` option is > 0, then apply the debounce
+		let repaintFn = repaint;
+
+		if (repaintDebounceMs > 0) {
+			repaintFn = debounce(repaint, repaintDebounceMs);
+		}
 
 		if (promise) {
 			return new Promise(resolve => {


### PR DESCRIPTION
…closes #478

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Performance improvement with a debounce

## Why?
Why not?

## How?
wraps the `CanvasEngine.repaintCanvas` method within a 60ms debounce

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


