### PR TITLE
Adding further events to LinkModel, NodeModel and PortModel

### DIFF
--- a/packages/geometry/src/BezierCurve.ts
+++ b/packages/geometry/src/BezierCurve.ts
@@ -19,7 +19,7 @@ export class BezierCurve extends Polygon {
 
 	setPoints(points: Point[]) {
 		if (points.length !== 4) {
-			throw new Error('BezierCurve must have extactly 4 points');
+			throw new Error('BezierCurve must have exactly 4 points');
 		}
 		super.setPoints(points);
 	}

--- a/packages/react-diagrams-core/src/entities/link/LinkModel.ts
+++ b/packages/react-diagrams-core/src/entities/link/LinkModel.ts
@@ -222,7 +222,8 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics> extends 
 			this.sourcePort.removeLink(this);
 		}
 		this.sourcePort = port;
-		this.fireEvent({ port }, 'sourcePortChanged');
+
+		this.fireEvent({ port }, 'linkSetSourcePort');
 	}
 
 	getSourcePort(): PortModel {
@@ -241,7 +242,8 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics> extends 
 			this.targetPort.removeLink(this);
 		}
 		this.targetPort = port;
-		this.fireEvent({ port }, 'targetPortChanged');
+
+		this.fireEvent({ port }, 'linkSetTargetPort');
 	}
 
 	point(x: number, y: number, index: number = 1): PointModel {

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -134,6 +134,16 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 	addPort(port: PortModel): PortModel {
 		port.setParent(this);
 		this.ports[port.getName()] = port;
+
+		port.registerListener({
+			portLinkRemoved: event => {
+				this.fireEvent({ ...event, port }, 'nodeLinkRemoved');
+			},
+			portLinkAdded: event => {
+				this.fireEvent({ ...event, port }, 'nodeLinkAdded');
+			}
+		});
+
 		return port;
 	}
 

--- a/packages/react-diagrams-core/src/entities/port/PortModel.ts
+++ b/packages/react-diagrams-core/src/entities/port/PortModel.ts
@@ -104,10 +104,14 @@ export class PortModel<G extends PortModelGenerics = PortModelGenerics> extends 
 
 	removeLink(link: LinkModel) {
 		delete this.links[link.getID()];
+
+		this.fireEvent({ link }, 'portLinkRemoved');
 	}
 
 	addLink(link: LinkModel) {
 		this.links[link.getID()] = link;
+
+		this.fireEvent({ link }, 'portLinkAdded');
 	}
 
 	getLinks(): { [id: string]: LinkModel } {

--- a/packages/react-diagrams-core/src/models/DiagramModel.ts
+++ b/packages/react-diagrams-core/src/models/DiagramModel.ts
@@ -115,13 +115,8 @@ export class DiagramModel<G extends DiagramModelGenerics = DiagramModelGenerics>
 
 	addLink(link: LinkModel): LinkModel {
 		this.getActiveLinkLayer().addModel(link);
-		this.fireEvent(
-			{
-				link,
-				isCreated: true
-			},
-			'linksUpdated'
-		);
+		this.fireEvent({ link, isCreated: true }, 'linksUpdated');
+
 		return link;
 	}
 

--- a/packages/react-diagrams-defaults/src/link/DefaultLinkWidget.tsx
+++ b/packages/react-diagrams-defaults/src/link/DefaultLinkWidget.tsx
@@ -59,6 +59,9 @@ export class DefaultLinkWidget extends React.Component<DefaultLinkProps, Default
 			this.props.link.addPoint(point, index);
 			event.persist();
 			event.stopPropagation();
+
+			this.props.link.fireEvent({ link: this.props.link }, 'newPointCreated');
+
 			this.forceUpdate(() => {
 				this.props.diagramEngine.getActionEventBus().fireAction({
 					event,


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
This pull request adds few new events to `LinkModel`, `NodeModel` and `PortModel`.

The new events are: 
- `portLinkAdded` - dispatched by PortModel when a new link is added
- `portLinkRemoved` - dispatched by PortModel when a link is removed
- `nodeLinkAdded` - dispatched by NodeModel when a new link is added to one of its port
- `nodeLinkRemoved` - dispatched by NodeModel when a link is removed from one of its port
- `linkSetSourcePort` - dispatched by LinkModel when a link's source port is set
- `linkSetTargetPort` - dispatched by LinkModel when a link's target port is set

## Why?
To possibly keep track of the links' state whilst creating/updating a new one. 

## How?
By adding few events

## Feel good image:

(Cheers)

![LOL](https://media.giphy.com/media/113JWfVDR9p5PG/giphy.gif)


