### PR TITLE
Unselect when not in Selection bounding box anymore.

### DIFF
--- a/packages/react-canvas-core/src/core-models/BaseModel.ts
+++ b/packages/react-canvas-core/src/core-models/BaseModel.ts
@@ -98,14 +98,16 @@ export class BaseModel<G extends BaseModelGenerics = BaseModelGenerics> extends 
 	}
 
 	setSelected(selected: boolean = true) {
-		this.options.selected = selected;
+		if (this.options.selected !== selected) {
+			this.options.selected = selected;
 
-		this.fireEvent(
-			{
-				isSelected: selected
-			},
-			'selectionChanged'
-		);
+			this.fireEvent(
+				{
+					isSelected: selected
+				},
+				'selectionChanged'
+			);
+		}
 	}
 
 	remove() {

--- a/packages/react-canvas-core/src/states/SelectionBoxState.ts
+++ b/packages/react-canvas-core/src/states/SelectionBoxState.ts
@@ -58,6 +58,8 @@ export class SelectionBoxState extends AbstractDisplacementState {
 				const bounds = ((model as unknown) as ModelGeometryInterface).getBoundingBox();
 				if (rect.containsPoint(bounds.getTopLeft()) && rect.containsPoint(bounds.getBottomRight())) {
 					model.setSelected(true);
+				} else {
+					model.setSelected(false);
 				}
 			}
 		}


### PR DESCRIPTION
Unselect when not in Selection bounding box anymore.

Performance optimisation to only fire event when value actually changed.

Solves #417

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

Unselect elements when using shift+select when they are not in the bounding box anymore.

Done performance optimisation because I noticed when shift+selecting, many times the setSelected function was called.

## Why?

To align with common selection box behaviour.

## How?

Unselect: If element is not in bounding box anymore, call setSelected(false) on that element.
Performance optimisation: add check whether value has changed

## Feel good image:


![PLEASE](http://www.lops.io/assets/img/post/lifeops-new-feature/meme-please-accept.jpg)


