### PR TITLE
Do deep clone instead of shallow clone.

### DIFF
--- a/packages/react-canvas-core/src/core-models/BaseEntity.ts
+++ b/packages/react-canvas-core/src/core-models/BaseEntity.ts
@@ -60,7 +60,7 @@ export class BaseEntity<T extends BaseEntityGenerics = BaseEntityGenerics> exten
 		if (lookupTable[this.options.id]) {
 			return lookupTable[this.options.id];
 		}
-		let clone = _.clone(this);
+		let clone = _.cloneDeep(this);
 		clone.options = {
 			...this.options,
 			id: Toolkit.UID()


### PR DESCRIPTION
Fixes #436

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

Perform deep clone instead of a shallow one

## Why?

Shallow clone keeps reference to original object

## How?

Use lodash its `cloneDeep` 

## Feel good image:

![CLONE](http://quickmeme.com/img/07/07f67fe7da4cda9f1354881e09002e749ed8048b16a15685ef44e60c2e853f57.jpg)


