### PR TITLE
Adds custom action story as an example

### DIFF
--- a/packages/diagrams-demo-gallery/demos/demo-custom-action/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-custom-action/index.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import createEngine, { DiagramModel, DefaultNodeModel, DefaultLinkModel } from '@projectstorm/react-diagrams';
+import { CanvasWidget, Action, ActionEvent, InputType } from '@projectstorm/react-canvas-core';
+import { DemoCanvasWidget } from '../helpers/DemoCanvasWidget';
+
+interface CustomDeleteItemsActionOptions {
+	keyCodes?: number[];
+}
+
+/**
+ * Deletes all selected items, but asks for confirmation first
+ */
+class CustomDeleteItemsAction extends Action {
+	constructor(options: CustomDeleteItemsActionOptions = {}) {
+		options = {
+			keyCodes: [46, 8],
+			...options
+		};
+		super({
+			type: InputType.KEY_DOWN,
+			fire: (event: ActionEvent<React.KeyboardEvent>) => {
+				if (options.keyCodes.indexOf(event.event.keyCode) !== -1) {
+					const selectedEntities = this.engine.getModel().getSelectedEntities();
+					if (selectedEntities.length > 0) {
+						const confirm = window.confirm('Are you sure you want to delete?');
+
+						if (confirm) {
+							_.forEach(selectedEntities, model => {
+								// only delete items which are not locked
+								if (!model.isLocked()) {
+									model.remove();
+								}
+							});
+							this.engine.repaintCanvas();
+						}
+					}
+				}
+			}
+		});
+	}
+}
+
+export default () => {
+	// create an engine without registering DeleteItemsAction
+	const engine = createEngine({ registerDefaultDeleteItemsAction: false });
+	const model = new DiagramModel();
+
+	const node1 = new DefaultNodeModel({ name: 'Node 1', color: 'rgb(0,192,255)' });
+	node1.setPosition(100, 100);
+	const port1 = node1.addOutPort('Out');
+
+	const node2 = new DefaultNodeModel('Node 2', 'rgb(192,255,0)');
+	const port2 = node2.addInPort('In');
+	node2.setPosition(400, 100);
+
+	const link1 = port1.link<DefaultLinkModel>(port2);
+	link1.getOptions().testName = 'Test';
+	link1.addLabel('Hello World!');
+
+	model.addAll(node1, node2, link1);
+
+	engine.setModel(model);
+
+	// register an DeleteItemsAction with custom keyCodes (in this case, only Delete key)
+	engine.getActionEventBus().registerAction(new CustomDeleteItemsAction());
+
+	return (
+		<DemoCanvasWidget>
+			<CanvasWidget engine={engine} />
+		</DemoCanvasWidget>
+	);
+};

--- a/packages/diagrams-demo-gallery/index.tsx
+++ b/packages/diagrams-demo-gallery/index.tsx
@@ -35,6 +35,7 @@ import demo_labels from './demos/demo-labelled-links';
 import demo_dynamic_ports from './demos/demo-dynamic-ports';
 import demo_alternative_linking from './demos/demo-alternative-linking';
 import demo_custom_delete_keys from './demos/demo-custom_delete_keys';
+import demo_custom_action from './demos/demo-custom-action';
 
 storiesOf('Simple Usage', module)
 	.add('Simple example', demo_simple)
@@ -68,10 +69,11 @@ import demo_cust_nodes from './demos/demo-custom-node1';
 import demo_cust_links from './demos/demo-custom-link1';
 import demo_cust_links2 from './demos/demo-custom-link2';
 
-storiesOf('Custom Models', module)
+storiesOf('Customization', module)
 	.add('Custom diamond node', demo_cust_nodes)
 	.add('Custom animated links', demo_cust_links)
-	.add('Custom link ends (arrows)', demo_cust_links2);
+	.add('Custom link ends (arrows)', demo_cust_links2)
+	.add('Custom event', demo_custom_action);
 
 import demo_3rd_dagre from './demos/demo-dagre';
 import demo_gsap from './demos/demo-animation';


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

Adds a new story that simply implements a custom action. This custom action is exactly like the `DeleteItemsAction`, but it asks for confirmation before deleting entities (but only if there is something selected).

![Peek 2020-01-07 18-45](https://user-images.githubusercontent.com/25781956/71932108-fcca2280-317d-11ea-810b-9833588b5059.gif)

Oh, and I also renamed the "Custom Models" to "Customization" on the stories group, just to be more generic.

## Why?

Because it was asked on [Gitter](https://gitter.im/projectstorm/react-diagrams?at=5e14ee9ea1e15049011c9f9a)

## How?
 
I only copied and pasted the `DeleteItemsAction` from `react-canvas-core` and added a confirmation :smile: 

## Feel good image:

![Literally "Feel Good" image](https://muffatosupermercados.vteximg.com.br/arquivos/ids/246158-400-400/7898192032618.jpg)


