### PR TITLE
emotion styling for DemoCanvasWidget background

### DIFF
--- a/packages/diagrams-demo-gallery/demos/helpers/DemoCanvasWidget.tsx
+++ b/packages/diagrams-demo-gallery/demos/helpers/DemoCanvasWidget.tsx
@@ -9,7 +9,7 @@ export interface DemoCanvasWidgetProps {
 namespace S {
 	export const Container = styled.div<{ color: string; background: string }>`
 		height: 100%;
-		background-color: rgb(60, 60, 60) !important;
+		background-color: ${p => p.background};
 		background-size: 50px 50px;
 		display: flex;
 


### PR DESCRIPTION
One-line fix to add support for customizing background color with `background` property in demo projects.

