### PR TITLE
fix DefaultNodeModel.removePort unbound splice #557

### DIFF
--- a/packages/react-diagrams-defaults/src/node/DefaultNodeModel.ts
+++ b/packages/react-diagrams-defaults/src/node/DefaultNodeModel.ts
@@ -44,9 +44,9 @@ export class DefaultNodeModel extends NodeModel<DefaultNodeModelGenerics> {
 	removePort(port: DefaultPortModel): void {
 		super.removePort(port);
 		if (port.getOptions().in) {
-			this.portsIn.splice(this.portsIn.indexOf(port));
+			this.portsIn.splice(this.portsIn.indexOf(port), 1);
 		} else {
-			this.portsOut.splice(this.portsOut.indexOf(port));
+			this.portsOut.splice(this.portsOut.indexOf(port), 1);
 		}
 	}
 


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [ ] The PR Template has been filled out (see below)

Fixes #557 by adding a `deleteCount` parameter to the `splice` calls with a value of 1 

