### PR TITLE
Add zoom to fit nodes feature, fixes #568

### DIFF
--- a/packages/diagrams-demo-gallery/demos/demo-zoom-to-fit-nodes/index.tsx
+++ b/packages/diagrams-demo-gallery/demos/demo-zoom-to-fit-nodes/index.tsx
@@ -1,0 +1,55 @@
+import createEngine, { DiagramModel, DefaultNodeModel } from '@projectstorm/react-diagrams';
+import * as React from 'react';
+import { DemoWorkspaceWidget, DemoButton } from '../helpers/DemoWorkspaceWidget';
+import { CanvasWidget } from '@projectstorm/react-canvas-core';
+import { DemoCanvasWidget } from '../helpers/DemoCanvasWidget';
+
+/**
+ *
+ * Simple stress test of the system plus zoom to fit function
+ *
+ * @Author Dylan Vorster
+ */
+export default () => {
+	//1) setup the diagram engine
+	var engine = createEngine();
+
+	//2) setup the diagram model
+	var model = new DiagramModel();
+
+	for (var i = 0; i < 8; i++) {
+		for (var j = 0; j < 8; j++) {
+			generateNodes(model, i * 200, j * 100);
+		}
+	}
+
+	//5) load model into engine
+	engine.setModel(model);
+
+	//6) render the diagram!
+	return (
+		<DemoWorkspaceWidget buttons={<DemoButton onClick={() => engine.zoomToFitNodes(50)}>Zoom to fit</DemoButton>}>
+			<DemoCanvasWidget>
+				<CanvasWidget engine={engine} />
+			</DemoCanvasWidget>
+		</DemoWorkspaceWidget>
+	);
+};
+
+function generateNodes(model: DiagramModel, offsetX: number, offsetY: number) {
+	//3-A) create a default node
+	var node1 = new DefaultNodeModel('Node 1', 'rgb(0,192,255)');
+	var port1 = node1.addOutPort('Out');
+	node1.setPosition(100 + offsetX, 100 + offsetY);
+
+	//3-B) create another default node
+	var node2 = new DefaultNodeModel('Node 2', 'rgb(192,255,0)');
+	var port2 = node2.addInPort('In');
+	node2.setPosition(200 + offsetX, 100 + offsetY);
+
+	//3-C) link the 2 nodes together
+	var link1 = port1.link(port2);
+
+	//4) add the models to the root graph
+	model.addAll(node1, node2, link1);
+}

--- a/packages/diagrams-demo-gallery/index.tsx
+++ b/packages/diagrams-demo-gallery/index.tsx
@@ -31,6 +31,7 @@ import demo_locks from './demos/demo-locks';
 import demo_grid from './demos/demo-grid';
 import demo_listeners from './demos/demo-listeners';
 import demo_zoom from './demos/demo-zoom-to-fit';
+import demo_zoom_nodes from './demos/demo-zoom-to-fit-nodes';
 import demo_labels from './demos/demo-labelled-links';
 import demo_dynamic_ports from './demos/demo-dynamic-ports';
 import demo_alternative_linking from './demos/demo-alternative-linking';
@@ -45,6 +46,7 @@ storiesOf('Simple Usage', module)
 	.add('Canvas grid size', demo_grid)
 	.add('Events and listeners', demo_listeners)
 	.add('Zoom to fit', demo_zoom)
+	.add('Zoom to fit nodes', demo_zoom_nodes)
 	.add('Dynamic ports', demo_dynamic_ports)
 	.add('Links with labels', demo_labels);
 


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Add zoom to fit selected nodes (or all nodes if there is no one selected) feature to diagram engine.

## Why?
_zoom to fit_ from canvas engine only uses zoom factors and was not centering on all nodes
 
