### PR TITLE
Listeners fix

### DIFF
--- a/packages/react-diagrams-core/src/entities/link/LinkWidget.tsx
+++ b/packages/react-diagrams-core/src/entities/link/LinkWidget.tsx
@@ -47,6 +47,8 @@ export class LinkWidget extends React.Component<LinkProps, LinkState> {
 
 	installTarget() {
 		this.targetListener && this.targetListener.deregister();
+
+		if (!this.props.link.getTargetPort()) return;
 		this.targetListener = this.props.link.getTargetPort().registerListener({
 			reportInitialPosition: (event: BaseEntityEvent<BasePositionModel>) => {
 				this.forceUpdate();
@@ -56,6 +58,8 @@ export class LinkWidget extends React.Component<LinkProps, LinkState> {
 
 	installSource() {
 		this.sourceListener && this.sourceListener.deregister();
+
+		if (!this.props.link.getSourcePort()) return;
 		this.sourceListener = this.props.link.getSourcePort().registerListener({
 			reportInitialPosition: (event: BaseEntityEvent<BasePositionModel>) => {
 				this.forceUpdate();

--- a/packages/react-diagrams-core/src/entities/node/NodeWidget.tsx
+++ b/packages/react-diagrams-core/src/entities/node/NodeWidget.tsx
@@ -36,6 +36,9 @@ export class NodeWidget extends React.Component<NodeProps> {
 	componentWillUnmount(): void {
 		this.ob.disconnect();
 		this.ob = null;
+
+		this.listener.deregister();
+		this.listener = null;
 	}
 
 	componentDidUpdate(prevProps: Readonly<NodeProps>, prevState: Readonly<any>, snapshot?: any): void {


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

1. Fixes `selectionChanged` listener not being deregistered on `NodeWidget`
2. Fixes unchecked access to `this.props.link.getSourcePort()` on `LinkWidget`

## Why?

1. After implementing undo & redo features on [logossim](https://github.com/renato-bohler/logossim), this warning started to appear after deleting a node, undoing its deletion and selecting it:
```
index.js:1 Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in NodeWidget (created by NodeLayerWidget)
```
2. After two consecutive deserializations on my project, if the deserialized model had a link, the following error was being thrown:
```
LinkWidget.tsx:59 Uncaught TypeError: Cannot read property 'registerListener' of null
    at LinkWidget.installSource (LinkWidget.tsx:59)
    at LinkWidget.componentDidUpdate (LinkWidget.tsx:68)
    (...)
```
To reproduce this:
1. Enter https://renato-bohler.github.io/logossim/
2. Add any component (bottom right corner)
3. Create a link on this component
4. Click the "Save" button (top right corner)
5. Click the "Load" button (top right corner)

There's a related issue, that was already closed: #589 

## How?
I `yarn link`ed all `react-diagram`'s packages into my project, made those small changes and tested it to make sure everything still works. Ran `yarn test:ci` and `yarn pretty`.

## Feel good image:

![LOL](https://i.pinimg.com/originals/d4/9d/d2/d49dd245f42359347d2f43c4e299b19d.jpg)


