### PR TITLE
Support deriving from DefaultLabelModel

### DIFF
--- a/packages/react-diagrams-defaults/src/label/DefaultLabelModel.tsx
+++ b/packages/react-diagrams-defaults/src/label/DefaultLabelModel.tsx
@@ -12,9 +12,9 @@ export interface DefaultLabelModelGenerics extends LabelModelGenerics {
 export class DefaultLabelModel extends LabelModel<DefaultLabelModelGenerics> {
 	constructor(options: DefaultLabelModelOptions = {}) {
 		super({
-			...options,
 			offsetY: options.offsetY == null ? -23 : options.offsetY,
-			type: 'default'
+			type: 'default',
+			...options
 		});
 	}
 


### PR DESCRIPTION
# Checklist

- [X ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI // I don't know how to check this, but I bet they do
- [X] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [X] The PR Template has been filled out (see below)
- [ ] Had a beer/coffee because you are awesome

## What?
The DefaultLabelModel constructor deviated from pattern followed by the other Default*Model types, where `...options` is merged after the hardcoded values so that derived classes can override the options. 

## Why?
I wanted to derive from DefaultLabelModel and was very confused when it just didn't work, since it had just worked perfectly for DefaultNodeModel.

## How?
This change makes it conform to the "...options after defaults" pattern.

## Feel good stuff
I have no image handy, but I'd like to say that this library is fantastic. I was a little nervous when I saw the minimal extant documentation, but after looking and the demos and digging into the code I really like it. This feels like the kind of framework that makes you into a better developer by learning it. Thanks to everyone who created it!


