### PR TITLE
Handle keydown/up events with no key data.

### DIFF
--- a/packages/react-canvas-core/src/core-actions/ActionEventBus.ts
+++ b/packages/react-canvas-core/src/core-actions/ActionEventBus.ts
@@ -52,12 +52,23 @@ export class ActionEventBus {
 		} else if (event.type === 'mouseup') {
 			return this.getActionsForType(InputType.MOUSE_UP);
 		} else if (event.type === 'keydown') {
+			// In rare cases (exact conditions unknown) the passed event is an Event
+			// rather than KeyboardEvent, so doesn't contain a key property. I prefer
+			// to test directly for whether key is present rather than the class:
+			// given we're already in weird territory let's not try and make
+			// assumptions from other information.
+			const key = (event as KeyboardEvent).key;
+			if (!key) return [];
+
 			// store the recorded key
-			this.keys[(event as KeyboardEvent).key.toLowerCase()] = true;
+			this.keys[key.toLowerCase()] = true;
 			return this.getActionsForType(InputType.KEY_DOWN);
 		} else if (event.type === 'keyup') {
+			const key = (event as KeyboardEvent).key;
+			if (!key) return [];
+
 			// delete the recorded key
-			delete this.keys[(event as KeyboardEvent).key.toLowerCase()];
+			delete this.keys[key.toLowerCase()];
 			return this.getActionsForType(InputType.KEY_UP);
 		} else if (event.type === 'mousemove') {
 			return this.getActionsForType(InputType.MOUSE_MOVE);


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

In certain repeatable yet rare cases I haven't quite been able to narrow down (at least involving the Tab key), the keydown and keyup events are not in fact `KeyboardEvent`s and do not contain key data. From this screenshot, you can see two bogus events but then also a legitimate one.

![diagrams-event-error](https://user-images.githubusercontent.com/1714/80276234-a849b380-872a-11ea-96d4-5bdafe5ae054.PNG)

While I haven't been able to figure out a minimal repro, my project is [open source](https://github.com/xaviershay/sandbox/tree/fld/factorio-layout-designer). Repro instructions in that project (after `yarn install && yarn start`) for Chrome on Ubuntu:

1. Drag "Blank" node from sidebar to canvas.
2. Double click title to edit.
3. Type "Gr" which should then show an autocomplete for "Green Circuit" (maybe you have to have edited the Green Circuit box first!? This is a browser suggestion, not done by the code).
4. Position the cursor over the autocomplete suggestion.
5. Press tab.


## Why?

Because it's broken otherwise.

## How?

With as little code as possible and a helpful comment.

## Feel good image:

(Add your own one below :])

![good dog](https://i.barkpost.com/wp-content/uploads/2014/06/pug-dog-riding-a-horse-540x360-540x300.jpg?q=70&fit=crop&crop=entropy&w=808&h=500)


