### PR TITLE
Fixing link spawning at (0,0) when clicking port once.

### DIFF
--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -71,12 +71,14 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 						if (this.port.canLinkToPort(model)) {
 							this.link.setTargetPort(model);
 							model.reportPosition();
+							this.engine.repaintCanvas();
+							return;
 						}
 						else if(this.isNearbySourcePort(event.event)) {
 							this.link.remove();
+							this.engine.repaintCanvas();
+							return;
 						}
-						this.engine.repaintCanvas();
-						return;
 					}
 					if (!this.config.allowLooseLinks) {
 						this.link.remove();

--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -71,12 +71,14 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 						if (this.port.canLinkToPort(model)) {
 							this.link.setTargetPort(model);
 							model.reportPosition();
-							this.engine.repaintCanvas();
-							return;
 						}
+						else if(this.isNearbySourcePort(event.event)) {
+							this.link.remove();
+						}
+						this.engine.repaintCanvas();
+						return;
 					}
-
-					if (this.isNearbySourcePort(event.event) || !this.config.allowLooseLinks) {
+					if (!this.config.allowLooseLinks) {
 						this.link.remove();
 						this.engine.repaintCanvas();
 					}
@@ -89,14 +91,14 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 	 * Checks whether the mouse event appears to happen in proximity of the link's source port
 	 * @param event
 	 */
-	isNearbySourcePort({ clientX, clientY }: MouseEvent): boolean {
+	isNearbySourcePort(event: MouseEvent): boolean {
 		const sourcePort = this.link.getSourcePort();
-		const sourcePortPosition = this.link.getSourcePort().getPosition();
+		const sourcePortPosition = (event.target as HTMLElement).getBoundingClientRect();
 
 		return (
-			clientX >= sourcePortPosition.x &&
-			clientX <= sourcePortPosition.x + sourcePort.width &&
-			(clientY >= sourcePortPosition.y && clientY <= sourcePortPosition.y + sourcePort.height)
+			event.clientX >= sourcePortPosition.x &&
+			event.clientX <= sourcePortPosition.x + sourcePort.width &&
+			(event.clientY >= sourcePortPosition.y && event.clientY <= sourcePortPosition.y + sourcePort.height)
 		);
 	}
 


### PR DESCRIPTION
# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Fixing the bug that happens when you click down and up on a port (it creates a link with the source being that port and the target point spawning at (0,0).
![Capture](https://user-images.githubusercontent.com/47562400/82015554-4d4b1280-967f-11ea-8228-4b95c189e37c.PNG)


## Why?
The bug was annoying.

## How?
Instead of getting the port position from the PortModel, get it from the HTMLElement, because the isNearbySourcePort method was comparing the position of the mouse in the viewport (clientX & clientY) with the position of the port in the canvas (which doesn't match when there is a top bar in the viewport).

## Feel good image:

Image related

![LOL](http://www.meh.ro/wp-content/uploads/2010/09/meh.ro5391.jpg)


