### PR TITLE
Remove @next from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Get started with the default models right out of the box:
 For all the bells and whistles:
 
 ```text
-yarn add @projectstorm/react-diagrams@next
+yarn add @projectstorm/react-diagrams
 ```
 
 This includes all the packages listed below \(and works \(mostly and conceptually\) like it used to in version 5.0\)
@@ -48,26 +48,26 @@ This includes all the packages listed below \(and works \(mostly and conceptuall
 This library now has a more modular design and you can import just the core \(contains no default factories or routing\)
 
 ```text
-yarn add @projectstorm/react-diagrams-core@next
+yarn add @projectstorm/react-diagrams-core
 ```
 
 this is built ontop of the evolving **react-canvas-core** library
 
 ```text
-yarn add @projectstorm/react-canvas-core@next
+yarn add @projectstorm/react-canvas-core
 ```
 
 which makes use of
 
 ```text
-yarn add @projectstorm/react-geometry@next
+yarn add @projectstorm/react-geometry
 ```
 
 and of course, you can add some extras:
 
 ```text
-yarn add @projectstorm/react-diagrams-defaults@next
-yarn add @projectstorm/react-diagrams-routing@next
+yarn add @projectstorm/react-diagrams-defaults
+yarn add @projectstorm/react-diagrams-routing
 ```
 
 ## How to use


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Remove `@next` from readme

## Why?
Using `@next` incorrectly installs latest beta release instead of the latest stable release which is currently newer than the latest beta release.

## How?
 Just edited the markdown

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


