### PR TITLE
Fix DragCanvasState to stop handling events after mouse is released

### DIFF
--- a/packages/react-canvas-core/src/core-state/AbstractDisplacementState.ts
+++ b/packages/react-canvas-core/src/core-state/AbstractDisplacementState.ts
@@ -35,6 +35,15 @@ export abstract class AbstractDisplacementState<E extends CanvasEngine = CanvasE
 				type: InputType.MOUSE_MOVE,
 				fire: (actionEvent: ActionEvent<React.MouseEvent>) => {
 					const { event } = actionEvent;
+
+					if (event.buttons === 0) {
+						// If buttons is 0, it means the mouse is not down, the user may have released it
+						// outside of the canvas, then we eject the state
+						this.eject();
+						
+						return;
+					}
+
 					this.fireMouseMoved({
 						displacementX: event.clientX - this.initialX,
 						displacementY: event.clientY - this.initialY,

--- a/packages/react-canvas-core/src/states/DragCanvasState.ts
+++ b/packages/react-canvas-core/src/states/DragCanvasState.ts
@@ -46,15 +46,6 @@ export class DragCanvasState extends AbstractDisplacementState {
 	}
 
 	fireMouseMoved(event: AbstractDisplacementStateEvent) {
-		const isMouseDown = event.event.buttons !== 0;
-
-		if (!isMouseDown) {
-			// If the mouse is not down, it should return to the previous state
-			// and stop processing the mouse move event
-			this.engine.getStateMachine().popState();
-			return;
-		}
-
 		if (this.config.allowDrag) {
 			this.engine
 				.getModel()

--- a/packages/react-canvas-core/src/states/DragCanvasState.ts
+++ b/packages/react-canvas-core/src/states/DragCanvasState.ts
@@ -46,6 +46,15 @@ export class DragCanvasState extends AbstractDisplacementState {
 	}
 
 	fireMouseMoved(event: AbstractDisplacementStateEvent) {
+		const isMouseDown = event.event.buttons !== 0;
+
+		if (!isMouseDown) {
+			// If the mouse is not down, it should return to the previous state
+			// and stop processing the mouse move event
+			this.engine.getStateMachine().popState();
+			return;
+		}
+
 		if (this.config.allowDrag) {
 			this.engine
 				.getModel()


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
This PR fixes a behavior on the `react-canvas-core` package.

## Why?
As a user, when moving the Canvas by the `drag` action, I expect that the canvas doesn't move with the mouse if I'm not pressing any mouse button.

## How?
When a user drags the chart and tries to "drop it outside" of the canvas area, then releases the mouse button, and move the mouse over the canvas again, currently, it's still assuming the `drag-canvas` state, when it could go back to the `default-canvas` state.
I tried to fix it that by adding a check on the `fireMouseMoved` function on the `DragCanvasState` class to see if the mouse is pressed when the event fires.

#### Current behavior:
![Screen Recording 2020-07-20 at 20 15 13](https://user-images.githubusercontent.com/38889364/87995560-392ff100-cac6-11ea-9006-ae5beacedbd3.gif)

#### After this change:
![Screen Recording 2020-07-20 at 20 16 39](https://user-images.githubusercontent.com/38889364/87995651-7a280580-cac6-11ea-9554-657aaed82cc9.gif)

## Feel good image:
![image](https://user-images.githubusercontent.com/38889364/87995723-a80d4a00-cac6-11ea-9fec-52f622455e63.png)



