### PR TITLE
Add missing dependencies in the documentation

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -22,8 +22,16 @@ When you run this in your project directory, this will install the library into 
 
 The library includes it's dependencies as peer-dependencies, so yarn will output warnings letting you know which ones are missing. Simple install them, specifically these ones:
 
+**Via yarn:**
+
 ```text
-yarn add closest lodash react ml-matrix dagre pathfinding paths-js @emotion/core
+yarn add closest lodash react ml-matrix dagre pathfinding paths-js @emotion/core @emotion/styled resize-observer-polyfill
+```
+
+**Via npm:**
+
+```text
+npm install closest lodash react ml-matrix dagre pathfinding paths-js @emotion/core @emotion/styled resize-observer-polyfill
 ```
 
 We do this, so that you can better control the versions of these libraries yourself since you might make use of `Lodash` in other parts of your software.


### PR DESCRIPTION
# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [ ] The PR Template has been filled out (see below)
- [ ] Had a beer/coffee because you are awesome

## What?


## Why?

`@emotion/styled` and `resize-observer-polyfill` dependencies are missing from the documentation

## How?
 
This PR adds those dependencies to the documentation and the command to install them with `npm`


