### PR TITLE
Fix #683 and #599; Drag and drop no longer crashes

### DIFF
--- a/packages/react-diagrams-core/src/entities/node/NodeWidget.tsx
+++ b/packages/react-diagrams-core/src/entities/node/NodeWidget.tsx
@@ -4,7 +4,7 @@ import { DiagramEngine } from '../../DiagramEngine';
 import { NodeModel } from './NodeModel';
 import { BaseEntityEvent, BaseModel, ListenerHandle, PeformanceWidget } from '@projectstorm/react-canvas-core';
 import styled from '@emotion/styled';
-import * as ResizeObserver from 'resize-observer-polyfill';
+import ResizeObserver from 'resize-observer-polyfill';
 
 export interface NodeProps {
 	node: NodeModel;

--- a/packages/react-diagrams-core/src/entities/node/NodeWidget.tsx
+++ b/packages/react-diagrams-core/src/entities/node/NodeWidget.tsx
@@ -4,7 +4,7 @@ import { DiagramEngine } from '../../DiagramEngine';
 import { NodeModel } from './NodeModel';
 import { BaseEntityEvent, BaseModel, ListenerHandle, PeformanceWidget } from '@projectstorm/react-canvas-core';
 import styled from '@emotion/styled';
-import ResizeObserver from 'resize-observer-polyfill';
+import * as ResizeObserver from 'resize-observer-polyfill';
 
 export interface NodeProps {
 	node: NodeModel;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
 	"compileOnSave": false,
 	"compilerOptions": {
+		"esModuleInterop":  true,
+		"allowSyntheticDefaultImports": true,
 		"suppressExcessPropertyErrors": true,
 		"declaration": false,
 		"strictNullChecks": false,


### PR DESCRIPTION
# Checklist

- [v] The code has been run through pretty `yarn run pretty`
- [?] The tests pass on CircleCI
- [v] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [v] The PR Template has been filled out (see below)
- [vvvvv] Had a beer/coffee because you are awesome

## What?
As detailed in #683 the library crashes under some conditions when using drag-and-drop.
This should also fix #599 which is what I used as a base for my project, where it works with this fix.

## Why?
The `resize-observer-polyfill` was not able to initialize and was crashing the app on drag-and-drop.

## How?
 This seems to be because of not importing the `resize-observer-polyfill` properly.

## Feel good image:

![I got your back](https://i.giphy.com/media/TGnoRs3OSdeOuPZieW/giphy.webp)


