### PR TITLE
Remove ml-matrix

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -25,13 +25,13 @@ The library includes it's dependencies as peer-dependencies, so yarn will output
 **Via yarn:**
 
 ```text
-yarn add closest lodash react ml-matrix dagre pathfinding paths-js @emotion/core @emotion/styled resize-observer-polyfill
+yarn add closest lodash react dagre pathfinding paths-js @emotion/core @emotion/styled resize-observer-polyfill
 ```
 
 **Via npm:**
 
 ```text
-npm install closest lodash react ml-matrix dagre pathfinding paths-js @emotion/core @emotion/styled resize-observer-polyfill
+npm install closest lodash react dagre pathfinding paths-js @emotion/core @emotion/styled resize-observer-polyfill
 ```
 
 We do this, so that you can better control the versions of these libraries yourself since you might make use of `Lodash` in other parts of your software.

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
 		"lodash": "4.*",
 		"pathfinding": "^0.4.18",
 		"paths-js": "^0.4.10",
-		"react": "16.*",
-    "ml-matrix": "6.*"
+		"react": "16.*"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.10.2",
@@ -74,7 +73,6 @@
 		"json-beautify": "^1.1.1",
 		"lerna": "^3.22.0",
 		"lodash": "4.*",
-		"ml-matrix": "^6.5.0",
 		"pathfinding": "^0.4.18",
 		"paths-js": "^0.4.10",
 		"prettier": "^2.0.5",

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -30,8 +30,5 @@
 	"main": "./dist/index.js",
 	"module": "./dist/es/index.js",
 	"typings": "./dist/@types/index",
-	"peerDependencies": {
-		"ml-matrix": "^6.5.0"
-	},
 	"gitHead": "bb878657ba0c2f81764f32901fd96158a0f8352e"
 }

--- a/packages/geometry/src/Matrix.ts
+++ b/packages/geometry/src/Matrix.ts
@@ -1,0 +1,27 @@
+export class Matrix {
+	matrix: number[][];
+
+	constructor(matrix: number[][]) {
+		this.matrix = matrix;
+	}
+
+	mmul = (matrix: Matrix): Matrix => {
+		// prettier-ignore
+		this.matrix = this.matrix.map((row, i) =>
+				matrix.asArray()[0].map((_, j) =>
+					row.reduce((acc, _, n) =>
+						acc + this.matrix[i][n] * matrix.asArray()[n][j], 0
+					)
+				)
+			);
+		return this;
+	};
+
+	asArray = (): number[][] => {
+		return this.matrix;
+	};
+
+	get = (rowIndex: number, columnIndex: number): number => {
+		return this.asArray()[rowIndex][columnIndex];
+	};
+}

--- a/packages/geometry/src/Point.ts
+++ b/packages/geometry/src/Point.ts
@@ -1,4 +1,4 @@
-import { Matrix } from 'ml-matrix';
+import { Matrix } from './Matrix';
 
 export class Point {
 	x: number;

--- a/packages/geometry/src/Polygon.ts
+++ b/packages/geometry/src/Polygon.ts
@@ -1,6 +1,6 @@
 import { Point } from './Point';
 import * as _ from 'lodash';
-import { Matrix } from 'ml-matrix';
+import { Matrix } from './Matrix';
 
 export class Polygon {
 	protected points: Point[];

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Point';
+export * from './Matrix';
 export * from './Polygon';
 export * from './Rectangle';
 export * from './BezierCurve';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7930,11 +7930,6 @@ is-alphanumerical@^1.0.0:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
 
-is-any-array@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/is-any-array/-/is-any-array-0.0.3.tgz#cbdd8c7189d47b53b050969245f4ef7e55550b9b"
-  integrity sha512-Lr5SRykZv6uuYMZURz7+YpigT1ziTBHOTgFJ1zK7gL+9Wbet5Ha1ws6S84Jo/lH4zep02b95sk6o4+MTk97mPQ==
-
 is-arguments@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
@@ -9857,36 +9852,6 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-ml-array-max@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/ml-array-max/-/ml-array-max-1.1.2.tgz#ac14a4954ebdb9f401774cc1572fce439e12f94d"
-  integrity sha512-it2hYUSuYEwIRO6hjTWfe6gbGutF4Tuct7jxt3LiLE4wKFs6ku5FLNIRKtOL2jyH+Jdwt1ddbqKMX8inBM8RxA==
-  dependencies:
-    is-any-array "^0.0.3"
-
-ml-array-min@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/ml-array-min/-/ml-array-min-1.1.2.tgz#a084370fe78998a4131d566d066ee01bccce253a"
-  integrity sha512-92QzvsyK7TxGz618pno6bu0LXYcRKssbimP85qRllk2xX5Z4gnVxlOmrMjSerUut9zzbt1eQB4byXNCwT0vgwA==
-  dependencies:
-    is-any-array "^0.0.3"
-
-ml-array-rescale@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ml-array-rescale/-/ml-array-rescale-1.3.1.tgz#7e55871af8741d212e2b47b8acd55571936c822b"
-  integrity sha512-PMj/f3MXBf5j2is8E4ugfNx6txi5y6qO4iVizfGjUVcpBl9RpXhznsoOz5iLtVtW1uDiWl+ToHaW4IGwoG+rmg==
-  dependencies:
-    is-any-array "^0.0.3"
-    ml-array-max "^1.1.2"
-    ml-array-min "^1.1.2"
-
-ml-matrix@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/ml-matrix/-/ml-matrix-6.5.0.tgz#3f3bbc54a694a0acf67feb7a750a903ac268d72c"
-  integrity sha512-sms732Dge+rs5dU4mnjE0oqLWm1WujvR2fr38LgUHRG2cjXjWlO3WJupLYaSz3++2iYr0UrGDK72OAivr3J8dg==
-  dependencies:
-    ml-array-rescale "^1.3.1"
 
 modify-values@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

The usage of `ml-matrix` was introduced here https://github.com/projectstorm/react-diagrams/pull/651/files?file-filters%5B%5D=.ts as substitute for the `mathjs` package.

This patch removes `ml-matrix`, because it's being used only to multiply two matrices, which can be done with a single line of js, no external packages.

## Why?

Using an external library (which is dragging 4 more libraries as dependencies) is an overkill if the same result can be achieved with a single line of code.
Dropping all those extra packages subtracts around 40kb in the final js bundle.

## How?
 
By replacing the `.mmul()` method.

## Does it actually work?

I made a small demo: https://repl.it/repls/OddAwareCopycat

## Extra

Those 2 issues can be closed after merging this PR:

* https://github.com/projectstorm/react-diagrams/issues/706
* https://github.com/projectstorm/react-diagrams/issues/627

