### PR TITLE
changed port array to store based on id

### DIFF
--- a/packages/react-canvas-core/src/core-state/AbstractDisplacementState.ts
+++ b/packages/react-canvas-core/src/core-state/AbstractDisplacementState.ts
@@ -40,7 +40,7 @@ export abstract class AbstractDisplacementState<E extends CanvasEngine = CanvasE
 						// If buttons is 0, it means the mouse is not down, the user may have released it
 						// outside of the canvas, then we eject the state
 						this.eject();
-						
+
 						return;
 					}
 

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -94,17 +94,8 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 	}
 
 	getPortFromID(id): PortModel | null {
-		for (var i in this.ports) {
-			if (this.ports[i].getID() === id) {
-				return this.ports[i];
-			}
-		}
-		return null;
-	}
-
-	getPortFromName(name): PortModel | null {
 		for (let i in this.ports) {
-			if (this.ports[i].getName() === name) {
+			if (this.ports[i].getID() === id) {
 				return this.ports[i];
 			}
 		}
@@ -121,7 +112,12 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 	}
 
 	getPort(name: string): PortModel | null {
-		return this.ports[name];
+		for (let i in this.ports) {
+			if (this.ports[i].getName() === name) {
+				return this.ports[i];
+			}
+		}
+		return null;
 	}
 
 	getPorts(): { [s: string]: PortModel } {

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -94,8 +94,17 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 	}
 
 	getPortFromID(id): PortModel | null {
-		for (var i in this.ports) {
+		for (let i in this.ports) {
 			if (this.ports[i].getID() === id) {
+				return this.ports[i];
+			}
+		}
+		return null;
+	}
+
+	getPortFromName(name): PortModel | null {
+		for (let i in this.ports) {
+			if (this.ports[i].getName() === name) {
 				return this.ports[i];
 			}
 		}
@@ -125,15 +134,15 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 			link.clearPort(port);
 		}
 		//clear the parent node reference
-		if (this.ports[port.getName()]) {
-			this.ports[port.getName()].setParent(null);
-			delete this.ports[port.getName()];
+		if (this.ports[port.getID()]) {
+			this.ports[port.getID()].setParent(null);
+			delete this.ports[port.getID()];
 		}
 	}
 
 	addPort(port: PortModel): PortModel {
 		port.setParent(this);
-		this.ports[port.getName()] = port;
+		this.ports[port.getID()] = port;
 		return port;
 	}
 

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -94,7 +94,12 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 	}
 
 	getPortFromID(id): PortModel | null {
-		return this.ports[id]
+		for (let i in this.ports) {
+			if (this.ports[i].getID() === id) {
+				return this.ports[i];
+			}
+		}
+		return null;
 	}
 
 	getLink(id: string): LinkModel {

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -94,12 +94,7 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 	}
 
 	getPortFromID(id): PortModel | null {
-		for (let i in this.ports) {
-			if (this.ports[i].getID() === id) {
-				return this.ports[i];
-			}
-		}
-		return null;
+		return this.ports[id]
 	}
 
 	getLink(id: string): LinkModel {

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -94,7 +94,7 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 	}
 
 	getPortFromID(id): PortModel | null {
-		for (let i in this.ports) {
+		for (var i in this.ports) {
 			if (this.ports[i].getID() === id) {
 				return this.ports[i];
 			}

--- a/packages/react-diagrams-core/src/entities/port/PortWidget.tsx
+++ b/packages/react-diagrams-core/src/entities/port/PortWidget.tsx
@@ -47,7 +47,7 @@ export class PortWidget extends React.Component<PortProps> {
 
 	getExtraProps() {
 		if (Toolkit.TESTING) {
-			const links = _.keys(this.props.port.getNode().getPort(this.props.port.getName()).links).join(',');
+			const links = _.keys(this.props.port.getNode().getPortFromID(this.props.port.getID()).links).join(',');
 			return {
 				'data-links': links
 			};


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

In reference to https://github.com/projectstorm/react-diagrams/issues/724 I think it is unwise to store ports based on a user provided name, as this can easily create clashes.  The unique ID is a less opinionated choice

## Why?

Well, personally I think I lost a couple hairs on my head because of this, hopefully this will prevent future hair loss :D 


## How?

Changed `addPort` and a couple other methods to store/pull ports based on ID instead of name

## Feel good image:

![LOL](https://i.redd.it/aveyb09f4qn51.jpg)


