### PR TITLE
Fixed failing tests in CircleCI & fixing a typo

### DIFF
--- a/packages/diagrams-demo-gallery/tests-e2e/helpers/E2ELink.ts
+++ b/packages/diagrams-demo-gallery/tests-e2e/helpers/E2ELink.ts
@@ -6,10 +6,10 @@ export class E2ELink extends E2EBase {
 	async select(): Promise<any> {
 		const point = await page.evaluate((id) => {
 			const path = document.querySelector(id) as SVGPathElement;
-			const point = path.getPointAtLength(path.getTotalLength() / 2);
+			const rect = path.getClientRects().item(0);
 			return {
-				x: point.x,
-				y: point.y
+				x: rect.x + rect.width / 2,
+				y: rect.y
 			};
 		}, this.selector());
 		await page.keyboard.down('Shift');

--- a/packages/react-diagrams-core/src/models/DiagramModel.ts
+++ b/packages/react-diagrams-core/src/models/DiagramModel.ts
@@ -76,7 +76,7 @@ export class DiagramModel<G extends DiagramModelGenerics = DiagramModelGenerics>
 		if (!this.activeLinkLayer) {
 			const layers = this.getLinkLayers();
 			if (layers.length === 0) {
-				this.addLayer(new NodeLayerModel());
+				this.addLayer(new LinkLayerModel());
 			} else {
 				this.activeLinkLayer = layers[0];
 			}

--- a/packages/react-diagrams-routing/tests/PathFinding.test.tsx
+++ b/packages/react-diagrams-routing/tests/PathFinding.test.tsx
@@ -1,6 +1,6 @@
 import PathFinding from '../src/engine/PathFinding';
 
-describe('calculating start and end points', () => {
+describe('calculating start and end points', function() {
 	beforeEach(() => {
 		this.pathFinding = new PathFinding(null);
 	});


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Fixed typo in packages/react-diagrams-core/src/models/DiagramModel.ts and failing tests in CircleCI

## Why?
1) packages/react-diagrams-core/src/models/DiagramModel.ts had a typo. NodeLayerModel was used when getting active link layer instead of LinkLayerModel

2) Tests were failing because of iframe.html has body padding set to 1rem. Because of that page.mouse.down svg based coordinates were missing the target path

## How?
1) Fixed typo

2) Using getClientRects() instead of svg getPointAtLength()

## Feel good image:
![LOL](https://miro.medium.com/max/4000/1*Wf-kv_vksuFWorLzokvkgg.jpeg)


