### PR TITLE
fix port background color

### DIFF
--- a/packages/react-diagrams-defaults/src/port/DefaultPortLabelWidget.tsx
+++ b/packages/react-diagrams-defaults/src/port/DefaultPortLabelWidget.tsx
@@ -23,7 +23,7 @@ namespace S {
 	export const Port = styled.div`
 		width: 15px;
 		height: 15px;
-		background: rgba(white, 0.1);
+		background: rgba(255, 255, 255, 0.1);
 
 		&:hover {
 			background: rgb(192, 255, 0);


### PR DESCRIPTION
## Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Default port widget contains incorrect CSS and port background was not painted as expected  

## Why?
rgba(white, 0.1) is not valid css

## How?
changed invalid syntax to valid

rgba syntax - `<rgba()> = rgba( <percentage>{3} [ / <alpha-value> ]? ) | rgba( <number>{3} [ / <alpha-value> ]? ) `

from https://developer.mozilla.org/en-US/docs/Web/CSS/background-color

## Images

Before:

![before](https://user-images.githubusercontent.com/8836773/95789953-243eb480-0ce7-11eb-8434-e6cbc891e10e.png)

After:

![after](https://user-images.githubusercontent.com/8836773/95789964-2b65c280-0ce7-11eb-8fe7-696ed18c9844.png)



