### PR TITLE
fix: MacOS Screenshot Issue

### DIFF
--- a/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
+++ b/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
@@ -64,6 +64,21 @@ export class CanvasWidget extends React.Component<DiagramProps> {
 		};
 		this.keyUp = (event) => {
 			this.props.engine.getActionEventBus().fireAction({ event });
+			
+			if (
+				this.props.engine.getActionEventBus().getKeys().length > 1 &&
+				this.props.engine
+					.getActionEventBus()
+					.getKeys()
+					.findIndex((key) => {
+						return key === 'shift';
+					}) !== -1
+			) {
+				// Prevent canvas from locking after MacOS screenshot by clearing actionEventBus keys array.
+				// Shift-Cmd-4 on mac duplicates the issue, because it pops up Preview as you're letting go of
+				// the shift key, and the browser doesn't see the key up event
+				(this.props.engine.getActionEventBus() as any).keys = []
+			}
 		};
 
 		document.addEventListener('keyup', this.keyUp);

--- a/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
+++ b/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
@@ -64,7 +64,7 @@ export class CanvasWidget extends React.Component<DiagramProps> {
 		};
 		this.keyUp = (event) => {
 			this.props.engine.getActionEventBus().fireAction({ event });
-			
+
 			if (
 				this.props.engine.getActionEventBus().getKeys().length > 1 &&
 				this.props.engine
@@ -77,7 +77,7 @@ export class CanvasWidget extends React.Component<DiagramProps> {
 				// Prevent canvas from locking after MacOS screenshot by clearing actionEventBus keys array.
 				// Shift-Cmd-4 on mac duplicates the issue, because it pops up Preview as you're letting go of
 				// the shift key, and the browser doesn't see the key up event
-				(this.props.engine.getActionEventBus() as any).keys = []
+				(this.props.engine.getActionEventBus() as any).keys = [];
 			}
 		};
 


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
The CanvasWidget locks up after taking a screenshot on MacOS.

## Why?
This can be replicated by `Shift + Cmd + 4`. The canvas "freezing" occurs because it pops up Preview as you're letting go of the shift key, and the browser doesn't detect the key up event

## How?
 This clears the Action Event Bus keys on keydown so the screenshot will still take but not lock the canvas
(shoutout to [chaiyixiao](https://github.com/chaiyixiao) for the help with this too)

## Feel good image:

![LOL](https://ktla.com/wp-content/uploads/sites/4/2020/04/GettyImages-1149292154.jpg?w=2560&h=1440&crop=1)


