### PR TITLE
Define Promise to be void to fix TS2794 error

### DIFF
--- a/packages/react-canvas-core/src/CanvasEngine.ts
+++ b/packages/react-canvas-core/src/CanvasEngine.ts
@@ -148,7 +148,7 @@ export class CanvasEngine<
 		}
 
 		if (promise) {
-			return new Promise((resolve) => {
+			return new Promise<void>((resolve) => {
 				const l = this.registerListener({
 					rendered: () => {
 						resolve();


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to -> N/A
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

Define Promise to be void to fix TS2794 error

## Why?

The following error occurs about the return type of Promise.

```
Expected 1 argument, but got 0. Did you forget to include 'void'
in your type argument to 'Promise'?
```

https://stackoverflow.com/questions/65354965/error-ts2794-expected-1-arguments-but-got-0-did-you-forget-to-include-void

## How?
 

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


