### PR TITLE
Export PathFinding from react-diagrams-routing

### DIFF
--- a/packages/react-diagrams-routing/src/index.ts
+++ b/packages/react-diagrams-routing/src/index.ts
@@ -5,5 +5,5 @@ export * from './link/RightAngleLinkWidget';
 export * from './link/RightAngleLinkFactory';
 export * from './link/RightAngleLinkModel';
 
-export * from './engine/PathFinding';
+export { default as PathFinding } from './engine/PathFinding';
 export * from './dagre/DagreEngine';


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Closes #336
Reexport `PathFinding` because it's unreachable right now

## Why?
It should be reachable for extending

## How?
With reexporting `default` from `react-diagrams-routing`

## Feel good image:

![LOL](https://pbs.twimg.com/media/DfDbaJJU0AA8fr2?format=jpg&name=360x360)


