### PR TITLE
Fix smart routing selection issue

### DIFF
--- a/packages/react-diagrams-defaults/src/link/DefaultLinkFactory.tsx
+++ b/packages/react-diagrams-defaults/src/link/DefaultLinkFactory.tsx
@@ -24,7 +24,7 @@ namespace S {
 	export const Path = styled.path<{ selected: boolean }>`
 		${(p) => p.selected && selected};
 		fill: none;
-		pointer-events: all;
+		pointer-events: auto;
 	`;
 }
 


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
If you will check smart routing demo you will find out that `PathFindingLink` becomes selected even when you moving mouse quite far from the path.

<img width="256" alt="screenshot" src="https://user-images.githubusercontent.com/16336572/109493081-022eae80-7a9d-11eb-926f-cdc072f67e39.png">

## Why?
The issue lays in `DefaultLinkFactory` which sets `pointer-events: all` to the actual path.

## How?
I see two possible options for fix it:
1. Extend `PathFindingLinkFactory` with `generateLinkSegment` method for overriding `DefaultLinkFactory` one
2. Change path `pointer-events` style from ` all` to `auto` in `DefaultLinkFactory`

I've chosen the second one because see no reason to have `pointer-events: all` there.

## Feel good image:

![LOL](https://user-images.githubusercontent.com/16336572/109493506-a9134a80-7a9d-11eb-9141-d7e876897003.png)


