### PR TITLE
Adds support for touch events, enabling touch dragging the canvas

### DIFF
--- a/diagrams-demo-gallery/demos/demo-alternative-linking/DefaultState.ts
+++ b/diagrams-demo-gallery/demos/demo-alternative-linking/DefaultState.ts
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import { MouseEvent, TouchEvent } from 'react';
 import {
 	SelectingState,
 	State,
@@ -41,6 +41,16 @@ export class DefaultState extends State<DiagramEngine> {
 					else {
 						this.transitionWithEvent(this.dragItems, event);
 					}
+				}
+			})
+		);
+
+		// touch drags the canvas
+		this.registerAction(
+			new Action({
+				type: InputType.TOUCH_START,
+				fire: (event: ActionEvent<TouchEvent>) => {
+					this.transitionWithEvent(new DragCanvasState(), event);
 				}
 			})
 		);

--- a/packages/react-canvas-core/src/core-actions/Action.ts
+++ b/packages/react-canvas-core/src/core-actions/Action.ts
@@ -1,4 +1,4 @@
-import { MouseEvent, KeyboardEvent, WheelEvent, SyntheticEvent } from 'react';
+import { MouseEvent, KeyboardEvent, WheelEvent, TouchEvent, SyntheticEvent } from 'react';
 import { Toolkit } from '../Toolkit';
 import { CanvasEngine } from '../CanvasEngine';
 import { BaseModel } from '../core-models/BaseModel';
@@ -9,7 +9,10 @@ export enum InputType {
 	MOUSE_MOVE = 'mouse-move',
 	MOUSE_WHEEL = 'mouse-wheel',
 	KEY_DOWN = 'key-down',
-	KEY_UP = 'key-up'
+	KEY_UP = 'key-up',
+	TOUCH_START = 'touch-start',
+	TOUCH_END = 'touch-end',
+	TOUCH_MOVE = 'touch-move'
 }
 
 export interface Mapping {
@@ -19,6 +22,9 @@ export interface Mapping {
 	[InputType.MOUSE_WHEEL]: WheelEvent;
 	[InputType.KEY_DOWN]: KeyboardEvent;
 	[InputType.KEY_UP]: KeyboardEvent;
+	[InputType.TOUCH_START]: TouchEvent;
+	[InputType.TOUCH_END]: TouchEvent;
+	[InputType.TOUCH_MOVE]: TouchEvent;
 }
 
 export interface ActionEvent<Event extends SyntheticEvent = SyntheticEvent, Model extends BaseModel = BaseModel> {

--- a/packages/react-canvas-core/src/core-actions/ActionEventBus.ts
+++ b/packages/react-canvas-core/src/core-actions/ActionEventBus.ts
@@ -63,7 +63,14 @@ export class ActionEventBus {
 			return this.getActionsForType(InputType.MOUSE_MOVE);
 		} else if (event.type === 'wheel') {
 			return this.getActionsForType(InputType.MOUSE_WHEEL);
+		} else if (event.type === 'touchstart') {
+			return this.getActionsForType(InputType.TOUCH_START);
+		} else if (event.type === 'touchend') {
+			return this.getActionsForType(InputType.TOUCH_END);
+		} else if (event.type === 'touchmove') {
+			return this.getActionsForType(InputType.TOUCH_MOVE);
 		}
+
 		return [];
 	}
 

--- a/packages/react-canvas-core/src/core-state/AbstractDisplacementState.ts
+++ b/packages/react-canvas-core/src/core-state/AbstractDisplacementState.ts
@@ -49,7 +49,7 @@ export abstract class AbstractDisplacementState<E extends CanvasEngine = CanvasE
 		this.registerAction(
 			new Action({
 				type: InputType.MOUSE_UP,
-				fire: () => this.handleMoveEnd(),
+				fire: () => this.handleMoveEnd()
 			})
 		);
 
@@ -75,7 +75,7 @@ export abstract class AbstractDisplacementState<E extends CanvasEngine = CanvasE
 		this.registerAction(
 			new Action({
 				type: InputType.TOUCH_END,
-				fire: () => this.handleMoveEnd(),
+				fire: () => this.handleMoveEnd()
 			})
 		);
 	}
@@ -94,7 +94,7 @@ export abstract class AbstractDisplacementState<E extends CanvasEngine = CanvasE
 			displacementY: y - this.initialY,
 			virtualDisplacementX: (x - this.initialX) / (this.engine.getModel().getZoomLevel() / 100.0),
 			virtualDisplacementY: (y - this.initialY) / (this.engine.getModel().getZoomLevel() / 100.0),
-			event,
+			event
 		});
 	}
 

--- a/packages/react-canvas-core/src/core-state/AbstractDisplacementState.ts
+++ b/packages/react-canvas-core/src/core-state/AbstractDisplacementState.ts
@@ -7,7 +7,7 @@ export interface AbstractDisplacementStateEvent {
 	displacementY: number;
 	virtualDisplacementX: number;
 	virtualDisplacementY: number;
-	event: React.MouseEvent;
+	event: React.MouseEvent | React.TouchEvent;
 }
 
 export abstract class AbstractDisplacementState<E extends CanvasEngine = CanvasEngine> extends State<E> {
@@ -58,6 +58,45 @@ export abstract class AbstractDisplacementState<E extends CanvasEngine = CanvasE
 			new Action({
 				type: InputType.MOUSE_UP,
 				fire: (event: ActionEvent<React.MouseEvent>) => {
+					// when the mouse if up, we eject this state
+					this.eject();
+				}
+			})
+		);
+
+		this.registerAction(
+			new Action({
+				type: InputType.TOUCH_START,
+				fire: (actionEvent: ActionEvent<React.TouchEvent>) => {
+					const touch = actionEvent.event.touches[0];
+					this.initialX = touch.clientX;
+					this.initialY = touch.clientY;
+					const rel = this.engine.getRelativePoint(touch.clientX, touch.clientY);
+					this.initialXRelative = rel.x;
+					this.initialYRelative = rel.y;
+				}
+			})
+		);
+		this.registerAction(
+			new Action({
+				type: InputType.TOUCH_MOVE,
+				fire: (actionEvent: ActionEvent<React.TouchEvent>) => {
+					const { event } = actionEvent;
+					const touch = event.touches[0];
+					this.fireMouseMoved({
+						displacementX: touch.clientX - this.initialX,
+						displacementY: touch.clientY - this.initialY,
+						virtualDisplacementX: (touch.clientX - this.initialX) / (this.engine.getModel().getZoomLevel() / 100.0),
+						virtualDisplacementY: (touch.clientY - this.initialY) / (this.engine.getModel().getZoomLevel() / 100.0),
+						event: event
+					});
+				}
+			})
+		);
+		this.registerAction(
+			new Action({
+				type: InputType.TOUCH_END,
+				fire: (event: ActionEvent<React.TouchEvent>) => {
 					// when the mouse if up, we eject this state
 					this.eject();
 				}

--- a/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
+++ b/packages/react-canvas-core/src/entities/canvas/CanvasWidget.tsx
@@ -90,6 +90,15 @@ export class CanvasWidget extends React.Component<DiagramProps> {
 				}}
 				onMouseMove={(event) => {
 					this.props.engine.getActionEventBus().fireAction({ event });
+				}}
+				onTouchStart={(event) => {
+					this.props.engine.getActionEventBus().fireAction({ event });
+				}}
+				onTouchEnd={(event) => {
+					this.props.engine.getActionEventBus().fireAction({ event });
+				}}
+				onTouchMove={(event) => {
+					this.props.engine.getActionEventBus().fireAction({ event });
 				}}>
 				{model.getLayers().map((layer) => {
 					return (

--- a/packages/react-canvas-core/src/entities/selection/SelectionBoxWidget.tsx
+++ b/packages/react-canvas-core/src/entities/selection/SelectionBoxWidget.tsx
@@ -17,7 +17,7 @@ export class SelectionBoxWidget extends React.Component<SelectionBoxWidgetProps>
 	render() {
 		const { rect } = this.props;
 
-		if (!rect) return;
+		if (!rect) return null;
 
 		return (
 			<S.Container

--- a/packages/react-canvas-core/src/entities/selection/SelectionBoxWidget.tsx
+++ b/packages/react-canvas-core/src/entities/selection/SelectionBoxWidget.tsx
@@ -16,6 +16,9 @@ namespace S {
 export class SelectionBoxWidget extends React.Component<SelectionBoxWidgetProps> {
 	render() {
 		const { rect } = this.props;
+
+		if (!rect) return;
+
 		return (
 			<S.Container
 				style={{

--- a/packages/react-canvas-core/src/states/DefaultState.ts
+++ b/packages/react-canvas-core/src/states/DefaultState.ts
@@ -1,6 +1,6 @@
 import { State } from '../core-state/State';
 import { Action, ActionEvent, InputType } from '../core-actions/Action';
-import { MouseEvent } from 'react';
+import { MouseEvent, TouchEvent } from 'react';
 import { DragCanvasState } from './DragCanvasState';
 import { SelectingState } from './SelectingState';
 import { MoveItemsState } from './MoveItemsState';
@@ -25,6 +25,16 @@ export class DefaultState extends State {
 					} else {
 						this.transitionWithEvent(new MoveItemsState(), event);
 					}
+				}
+			})
+		);
+
+		// touch drags the canvas
+		this.registerAction(
+			new Action({
+				type: InputType.TOUCH_START,
+				fire: (event: ActionEvent<TouchEvent>) => {
+					this.transitionWithEvent(new DragCanvasState(), event);
 				}
 			})
 		);

--- a/packages/react-canvas-core/src/states/SelectionBoxState.ts
+++ b/packages/react-canvas-core/src/states/SelectionBoxState.ts
@@ -1,7 +1,8 @@
+import { MouseEvent, TouchEvent } from 'react';
 import { AbstractDisplacementState, AbstractDisplacementStateEvent } from '../core-state/AbstractDisplacementState';
 import { State } from '../core-state/State';
 import { SelectionLayerModel } from '../entities/selection/SelectionLayerModel';
-import { Rectangle } from '@projectstorm/geometry';
+import { Point, Rectangle } from '@projectstorm/geometry';
 import { ModelGeometryInterface } from '../core/ModelGeometryInterface';
 
 export class SelectionBoxState extends AbstractDisplacementState {
@@ -26,7 +27,13 @@ export class SelectionBoxState extends AbstractDisplacementState {
 	}
 
 	getBoxDimensions(event: AbstractDisplacementStateEvent): ClientRect {
-		const rel = this.engine.getRelativePoint(event.event.clientX, event.event.clientY);
+		let rel: Point;
+		if (event.event instanceof MouseEvent) {
+			rel = this.engine.getRelativePoint(event.event.clientX, event.event.clientY);
+		} else if (event.event instanceof TouchEvent) {
+			const touch = event.event.touches[0];
+			rel = this.engine.getRelativePoint(touch.clientX, touch.clientY);
+		}
 
 		return {
 			left: rel.x > this.initialXRelative ? this.initialXRelative : rel.x,

--- a/packages/react-diagrams-core/src/states/DefaultDiagramState.ts
+++ b/packages/react-diagrams-core/src/states/DefaultDiagramState.ts
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import { MouseEvent, TouchEvent } from 'react';
 import {
 	SelectingState,
 	State,
@@ -45,6 +45,16 @@ export class DefaultDiagramState extends State<DiagramEngine> {
 					else {
 						this.transitionWithEvent(this.dragItems, event);
 					}
+				}
+			})
+		);
+
+		// touch drags the canvas
+		this.registerAction(
+			new Action({
+				type: InputType.TOUCH_START,
+				fire: (event: ActionEvent<TouchEvent>) => {
+					this.transitionWithEvent(this.dragCanvas, event);
 				}
 			})
 		);


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a ~~beer/coffee~~ coke because you are awesome

## What?
Adds support for touch events (`touchstart`, `touchmove` and `touchend`). Enables touch dragging the canvas by default.

**P.S.:** this is already working on [logossim](https://renato-bohler.github.io/logossim/), changes applied using `patch-package` on this PR: https://github.com/renato-bohler/logossim/pull/59

Example:

https://user-images.githubusercontent.com/25781956/114326338-b0049280-9b0a-11eb-909c-2d2340bcfcd6.mp4

## Why?
Improves mobile support. Even though it doesn't completely makes touch-based devices supported, this makes it possible for developers to implement full support on their applications (by customizing State).

## How?
1. Added 3 touch events to `InputType`.
2. Changed `getActionsForEvent` method on `ActionEventBus`.
3. Changed `AbstractDisplacementState` to listen for touch events.
4. Added `onTouch(Start/End/Move)` event handlers on `CanvasWidget`.
5. Updated the `DefaultState`.
6. Updated examples.

## Feel good image:
![image](https://user-images.githubusercontent.com/25781956/114326538-aaf41300-9b0b-11eb-8d06-6895522ac99c.png)



