### PR TITLE
Fix CI failure on master and bug `Cannot read property 'reportedPosition' of null on link.setSourcePort and link.setSourceTarget`

### DIFF
--- a/packages/react-diagrams-core/src/entities/link/LinkModel.ts
+++ b/packages/react-diagrams-core/src/entities/link/LinkModel.ts
@@ -215,7 +215,7 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 		return this.points[this.points.length - 1];
 	}
 
-	setSourcePort(port: PortModel) {
+	setSourcePort(port: PortModel | null) {
 		if (port !== null) {
 			port.addLink(this);
 		}
@@ -224,7 +224,7 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 		}
 		this.sourcePort = port;
 		this.fireEvent({ port }, 'sourcePortChanged');
-		if (port.reportedPosition) {
+		if (port?.reportedPosition) {
 			this.getPointForPort(port).setPosition(port.getCenter());
 		}
 	}
@@ -237,7 +237,7 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 		return this.targetPort;
 	}
 
-	setTargetPort(port: PortModel) {
+	setTargetPort(port: PortModel | null) {
 		if (port !== null) {
 			port.addLink(this);
 		}
@@ -246,7 +246,7 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 		}
 		this.targetPort = port;
 		this.fireEvent({ port }, 'targetPortChanged');
-		if (port.reportedPosition) {
+		if (port?.reportedPosition) {
 			this.getPointForPort(port).setPosition(port.getCenter());
 		}
 	}

--- a/packages/react-diagrams-routing/tests/PathFinding.test.tsx
+++ b/packages/react-diagrams-routing/tests/PathFinding.test.tsx
@@ -1,4 +1,4 @@
-import PathFinding from '../src/engine/PathFinding';
+import { PathFinding } from '../src/engine/PathFinding';
 
 describe('calculating start and end points', function () {
 	beforeEach(() => {


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
We've got an error `Uncaught TypeError: Cannot read property 'reportedPosition' of null
    at DefaultLinkModel.setSourcePort` when we use `link.clearPort(port)`

## Why?
Because we call then `link.setSourcePort(null)` or `link.setTargetPort(null)` to remove port from link. 
https://github.com/projectstorm/react-diagrams/blob/d2f05438b8620147d7aa835f2799a0f56397d4e3/packages/react-diagrams-core/src/entities/link/LinkModel.ts#L156
https://github.com/projectstorm/react-diagrams/blob/d2f05438b8620147d7aa835f2799a0f56397d4e3/packages/react-diagrams-core/src/entities/link/LinkModel.ts#L158
But this methods  doesn't check port existence before using `reportPosition` property.
https://github.com/projectstorm/react-diagrams/blob/d2f05438b8620147d7aa835f2799a0f56397d4e3/packages/react-diagrams-core/src/entities/link/LinkModel.ts#L227
https://github.com/projectstorm/react-diagrams/blob/d2f05438b8620147d7aa835f2799a0f56397d4e3/packages/react-diagrams-core/src/entities/link/LinkModel.ts#L249

## How?
At first we need to expect null as input there for type safety. Then we would check port existence before using it's property

## Feel good image:

![LOL](https://static.wikia.nocookie.net/starwars/images/c/c9/Report_Sedition.png/revision/latest?cb=20170305063027)