### PR TITLE
Update broken link to diagrams-demo-gallery in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ yarn add @projectstorm/react-diagrams-routing
 Before running any of the examples, please run `yarn build` in the root. This project is a monorepo, and the packages (including the demos) require the packages to first be built.
 
 
-Take a look at the [diagram demos](https://github.com/projectstorm/react-diagrams/tree/master/packages/diagrams-demo-gallery/demos)
+Take a look at the [diagram demos](https://github.com/projectstorm/react-diagrams/tree/master/diagrams-demo-gallery/demos)
 
 **or**
 
-Take a look at the [demo project](https://github.com/projectstorm/react-diagrams/tree/master/packages/diagrams-demo-project) which contains an example for ES6 as well as Typescript
+Take a look at the [demo project](https://github.com/projectstorm/react-diagrams/tree/master/diagrams-demo-project) which contains an example for ES6 as well as Typescript
 
 **or**
 
@@ -85,7 +85,7 @@ Take a look at the [demo project](https://github.com/projectstorm/react-diagrams
 
 ## Run the demos
 
-After running `yarn install` you must then run: `cd packages/diagrams-demo-gallery && yarn run start`
+After running `yarn install` you must then run: `cd diagrams-demo-gallery && yarn run start`
 
 ## Building from source
 


### PR DESCRIPTION

# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [ ] The PR Template has been filled out (see below)
- [ ] Had a beer/coffee because you are awesome

## What?
When following instructions locally, I noticed that references to `packages/diagrams-demo-gallery` should be updated to remove `packages` from the path so that the links do not lead to Github 404s. I also noticed a reference to `cd` into that same directory, which appears to have moved

## Why?
The links lead to Github 404s

## How?
Just a readme change

## Feel good image:
![turtle](https://live.staticflickr.com/8426/7527365540_704661f09e_b.jpg)


