### PR TITLE
Fixes removeMiddlePoints in LinkModel.ts.

### DIFF
--- a/packages/react-diagrams-core/src/entities/link/LinkModel.ts
+++ b/packages/react-diagrams-core/src/entities/link/LinkModel.ts
@@ -289,7 +289,7 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 
 	removeMiddlePoints() {
 		if (this.points.length > 2) {
-			this.points.splice(0, this.points.length - 2);
+			this.points.splice(1, this.points.length - 2);
 		}
 	}
 


### PR DESCRIPTION
RemoveMiddlePoints removed the first point from points, while it should not delete the startpoint.

# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Fixes the removeMiddlePoints function in the LinkModel.

## Why?
The removeMiddlePoints function removes the startpoint of a link. The function should only remove points between start and endpoint.

## How?
Updated the function to skip the first point.

## Feel good image:

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


