### PR TITLE
fix: MoveItemsState should use BasePositionModel instead BaseModel

### DIFF
--- a/packages/react-canvas-core/src/states/MoveItemsState.ts
+++ b/packages/react-canvas-core/src/states/MoveItemsState.ts
@@ -3,7 +3,6 @@ import { State } from '../core-state/State';
 import { Action, ActionEvent, InputType } from '../core-actions/Action';
 import { BasePositionModel } from '../core-models/BasePositionModel';
 import { Point } from '@projectstorm/geometry';
-import { BaseModel } from '../core-models/BaseModel';
 import { CanvasEngine } from '../CanvasEngine';
 
 export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends AbstractDisplacementState<E> {

--- a/packages/react-canvas-core/src/states/MoveItemsState.ts
+++ b/packages/react-canvas-core/src/states/MoveItemsState.ts
@@ -10,7 +10,7 @@ export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends Abstr
 	initialPositions: {
 		[id: string]: {
 			point: Point;
-			item: BaseModel;
+			item: BasePositionModel;
 		};
 	};
 


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

MoveItemsState can't hold BaseModel in `initialPositions`

## Why?
Because position come from BasePositionModel

## How?
Accept only BasePositionItems here

## Feel good image:

![LOL](https://images-na.ssl-images-amazon.com/images/I/71OgCja-ZOL._AC_SX425_.jpg)


