### PR TITLE
Fix parent prop on port cloning

### DIFF
--- a/packages/react-diagrams-core/src/entities/port/PortModel.ts
+++ b/packages/react-diagrams-core/src/entities/port/PortModel.ts
@@ -81,9 +81,9 @@ export class PortModel<G extends PortModelGenerics = PortModelGenerics> extends 
 		});
 	}
 
-	doClone(lookupTable = {}, clone) {
+	doClone(lookupTable = {}, clone: PortModel) {
 		clone.links = {};
-		clone.parentNode = this.getParent().clone(lookupTable);
+		clone.parent = this.getParent().clone(lookupTable);
 	}
 
 	getNode(): NodeModel {


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Port lost parent on clone

## Why?
Because parent wrote to unused parentNode parent instead of parent

## How?
Rename prop from parentNode to parent, then on this.getParent() we can get correct parent

## Feel good image:

![image](https://user-images.githubusercontent.com/16336572/126635622-1f6bff44-3536-4af1-8528-29e476c8ca13.png)


