### PR TITLE
Fix touch with mouse event bug on selection box usage

### DIFF
--- a/packages/react-canvas-core/src/states/SelectionBoxState.ts
+++ b/packages/react-canvas-core/src/states/SelectionBoxState.ts
@@ -1,4 +1,3 @@
-import { MouseEvent, TouchEvent } from 'react';
 import { AbstractDisplacementState, AbstractDisplacementStateEvent } from '../core-state/AbstractDisplacementState';
 import { State } from '../core-state/State';
 import { SelectionLayerModel } from '../entities/selection/SelectionLayerModel';
@@ -28,11 +27,12 @@ export class SelectionBoxState extends AbstractDisplacementState {
 
 	getBoxDimensions(event: AbstractDisplacementStateEvent): ClientRect {
 		let rel: Point;
-		if (event.event instanceof MouseEvent) {
-			rel = this.engine.getRelativePoint(event.event.clientX, event.event.clientY);
-		} else if (event.event instanceof TouchEvent) {
+
+		if ('touches' in event.event) {
 			const touch = event.event.touches[0];
 			rel = this.engine.getRelativePoint(touch.clientX, touch.clientY);
+		} else {
+			rel = this.engine.getRelativePoint(event.event.clientX, event.event.clientY);
 		}
 
 		return {


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Getting `Uncaught TypeError: Cannot read properties of undefined (reading 'x')` when using SelectionBox

Closes https://github.com/projectstorm/react-diagrams/issues/867

## Why?
Because SelectionBox code uses interface as class with `instanceof`. It's always `false`.

## How?
Remove `instanceof` usage and rely on object props.

## Feel good image:

![image](https://user-images.githubusercontent.com/16336572/126689267-96d40acc-6fcc-4899-ad45-767826fff658.png)


