### PR TITLE
Fix the zoomToFitNodes offsets calculation

### DIFF
--- a/packages/react-diagrams-core/src/DiagramEngine.ts
+++ b/packages/react-diagrams-core/src/DiagramEngine.ts
@@ -270,14 +270,12 @@ export class DiagramEngine extends CanvasEngine<CanvasEngineListener, DiagramMod
 					zoom: zoomFactor,
 					x:
 						canvasRect.width / 2 -
-						((nodesRect.getWidth() + margin * 2) * zoomFactor) / 2 +
-						margin -
-						nodesRect.getTopLeft().x,
+						((nodesRect.getWidth() + margin * 2) / 2 + nodesRect.getTopLeft().x) * zoomFactor +
+						margin,
 					y:
 						canvasRect.height / 2 -
-						((nodesRect.getHeight() + margin * 2) * zoomFactor) / 2 +
-						margin -
-						nodesRect.getTopLeft().y
+						((nodesRect.getHeight() + margin * 2) / 2 + nodesRect.getTopLeft().y) * zoomFactor +
+						margin
 				};
 			};
 


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
The offset calculation method in the `DiagramEngine.zoomToFitNodes` has problems. This PR fixes the issue

### Before
![before](https://user-images.githubusercontent.com/70665354/129423266-b2b51ccb-d4b4-40e0-824f-89969a6978ec.gif)

### After
![after](https://user-images.githubusercontent.com/70665354/129423271-c11f6af5-452f-4259-b9e1-8144192a31e4.gif)

## Why?


## How?
The nodes bounding box's coordinates were not scaled by the zoom factor causing this bug

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


