### PR TITLE
Update DefaultPortModel.ts

### DIFF
--- a/packages/react-diagrams-defaults/src/port/DefaultPortModel.ts
+++ b/packages/react-diagrams-defaults/src/port/DefaultPortModel.ts
@@ -11,6 +11,7 @@ import { AbstractModelFactory, DeserializeEvent } from '@projectstorm/react-canv
 export interface DefaultPortModelOptions extends PortModelOptions {
 	label?: string;
 	in?: boolean;
+	type?: string;
 }
 
 export interface DefaultPortModelGenerics extends PortModelGenerics {


### PR DESCRIPTION
this is about fixing a type error when creating custom port model;
when making custom port widget with custom styled link, I need to make a custom port model, which need a custom type in constructor's options object, but options.type is missing in the DefaultPortModel constructor props type. 
So I added it in.

# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [ ] The PR Template has been filled out (see below)
- [ ] Had a beer/coffee because you are awesome


## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


