### PR TITLE
Fix set position bug

### DIFF
--- a/packages/react-canvas-core/src/core-models/BasePositionModel.ts
+++ b/packages/react-canvas-core/src/core-models/BasePositionModel.ts
@@ -18,8 +18,7 @@ export interface BasePositionModelGenerics extends BaseModelGenerics {
 
 export class BasePositionModel<G extends BasePositionModelGenerics = BasePositionModelGenerics>
 	extends BaseModel<G>
-	implements ModelGeometryInterface
-{
+	implements ModelGeometryInterface {
 	protected position: Point;
 
 	constructor(options: G['OPTIONS']) {
@@ -27,12 +26,12 @@ export class BasePositionModel<G extends BasePositionModelGenerics = BasePositio
 		this.position = options.position || new Point(0, 0);
 	}
 
-	setPosition(point: Point);
-	setPosition(x: number, y: number);
-	setPosition(x, y?) {
-		if (typeof x === 'object') {
+	setPosition(point: Point): void;
+	setPosition(x: number, y: number): void;
+	setPosition(x: number | Point, y?: number): void {
+		if (x instanceof Point) {
 			this.position = x;
-		} else if (typeof x) {
+		} else {
 			this.position = new Point(x, y);
 		}
 		this.fireEvent({}, 'positionChanged');

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -52,7 +52,7 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 
 		//also update the port co-ordinates (for make glorious speed)
 		_.forEach(this.ports, (port) => {
-			port.setPosition(port.getX() + this.getPosition().x - old.x, port.getY() + this.getPosition().y - old.y);
+			port.setPosition(port.getX() + this.position.x - old.x, port.getY() + this.position.y - old.y);
 		});
 	}
 

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -42,7 +42,7 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 	setPosition(point: Point): void;
 	setPosition(x: number, y: number): void;
 	setPosition(x: number | Point, y?: number): void {
-		let old = this.position;
+		const old = this.position;
 
 		if (x instanceof Point) {
 			super.setPosition(x);

--- a/packages/react-diagrams-core/src/entities/node/NodeModel.ts
+++ b/packages/react-diagrams-core/src/entities/node/NodeModel.ts
@@ -39,15 +39,20 @@ export class NodeModel<G extends NodeModelGenerics = NodeModelGenerics> extends 
 		return new Rectangle(this.getPosition(), this.width, this.height);
 	}
 
-	setPosition(point: Point);
-	setPosition(x: number, y: number);
-	setPosition(x, y?) {
+	setPosition(point: Point): void;
+	setPosition(x: number, y: number): void;
+	setPosition(x: number | Point, y?: number): void {
 		let old = this.position;
-		super.setPosition(x, y);
+
+		if (x instanceof Point) {
+			super.setPosition(x);
+		} else {
+			super.setPosition(x, y);
+		}
 
 		//also update the port co-ordinates (for make glorious speed)
 		_.forEach(this.ports, (port) => {
-			port.setPosition(port.getX() + x - old.x, port.getY() + y - old.y);
+			port.setPosition(port.getX() + this.getPosition().x - old.x, port.getY() + this.getPosition().y - old.y);
 		});
 	}
 

--- a/packages/react-diagrams-core/src/entities/port/PortModel.ts
+++ b/packages/react-diagrams-core/src/entities/port/PortModel.ts
@@ -81,7 +81,7 @@ export class PortModel<G extends PortModelGenerics = PortModelGenerics> extends 
 		}
 		_.forEach(this.getLinks(), (link) => {
 			const point = link.getPointForPort(this);
-			point.setPosition(point.getX() + this.getPosition().x - old.x, point.getY() + this.getPosition().y - old.y);
+			point.setPosition(point.getX() + this.position.x - old.x, point.getY() + this.position.y - old.y);
 		});
 	}
 

--- a/packages/react-diagrams-core/src/entities/port/PortModel.ts
+++ b/packages/react-diagrams-core/src/entities/port/PortModel.ts
@@ -70,21 +70,6 @@ export class PortModel<G extends PortModelGenerics = PortModelGenerics> extends 
 		};
 	}
 
-	setPosition(point: Point): void;
-	setPosition(x: number, y: number): void;
-	setPosition(x: number | Point, y?: number): void {
-		const old = this.position;
-		if (x instanceof Point) {
-			super.setPosition(x);
-		} else {
-			super.setPosition(x, y);
-		}
-		_.forEach(this.getLinks(), (link) => {
-			const point = link.getPointForPort(this);
-			point.setPosition(point.getX() + this.position.x - old.x, point.getY() + this.position.y - old.y);
-		});
-	}
-
 	doClone(lookupTable = {}, clone: PortModel) {
 		clone.links = {};
 		clone.parent = this.getParent().clone(lookupTable);

--- a/packages/react-diagrams-core/src/entities/port/PortModel.ts
+++ b/packages/react-diagrams-core/src/entities/port/PortModel.ts
@@ -1,4 +1,4 @@
-const { NodeModel } from '../node/NodeModel';
+import { NodeModel } from '../node/NodeModel';
 import { LinkModel } from '../link/LinkModel';
 import * as _ from 'lodash';
 import { Point, Rectangle } from '@projectstorm/geometry';

--- a/packages/react-diagrams-core/src/entities/port/PortModel.ts
+++ b/packages/react-diagrams-core/src/entities/port/PortModel.ts
@@ -70,14 +70,18 @@ export class PortModel<G extends PortModelGenerics = PortModelGenerics> extends 
 		};
 	}
 
-	setPosition(point: Point);
-	setPosition(x: number, y: number);
-	setPosition(x, y?) {
+	setPosition(point: Point): void;
+	setPosition(x: number, y: number): void;
+	setPosition(x: number | Point, y?: number): void {
 		let old = this.position;
-		super.setPosition(x, y);
+		if (x instanceof Point) {
+			super.setPosition(x);
+		} else {
+			super.setPosition(x, y);
+		}
 		_.forEach(this.getLinks(), (link) => {
 			let point = link.getPointForPort(this);
-			point.setPosition(point.getX() + x - old.x, point.getY() + y - old.y);
+			point.setPosition(point.getX() + this.getPosition().x - old.x, point.getY() + this.getPosition().y - old.y);
 		});
 	}
 

--- a/packages/react-diagrams-core/src/entities/port/PortModel.ts
+++ b/packages/react-diagrams-core/src/entities/port/PortModel.ts
@@ -1,4 +1,4 @@
-import { NodeModel } from '../node/NodeModel';
+const { NodeModel } from '../node/NodeModel';
 import { LinkModel } from '../link/LinkModel';
 import * as _ from 'lodash';
 import { Point, Rectangle } from '@projectstorm/geometry';
@@ -73,14 +73,14 @@ export class PortModel<G extends PortModelGenerics = PortModelGenerics> extends 
 	setPosition(point: Point): void;
 	setPosition(x: number, y: number): void;
 	setPosition(x: number | Point, y?: number): void {
-		let old = this.position;
+		const old = this.position;
 		if (x instanceof Point) {
 			super.setPosition(x);
 		} else {
 			super.setPosition(x, y);
 		}
 		_.forEach(this.getLinks(), (link) => {
-			let point = link.getPointForPort(this);
+			const point = link.getPointForPort(this);
 			point.setPosition(point.getX() + this.getPosition().x - old.x, point.getY() + this.getPosition().y - old.y);
 		});
 	}

--- a/packages/react-diagrams-core/src/entities/port/PortModel.ts
+++ b/packages/react-diagrams-core/src/entities/port/PortModel.ts
@@ -70,6 +70,17 @@ export class PortModel<G extends PortModelGenerics = PortModelGenerics> extends 
 		};
 	}
 
+	setPosition(point: Point);
+	setPosition(x: number, y: number);
+	setPosition(x, y?) {
+		let old = this.position;
+		super.setPosition(x, y);
+		_.forEach(this.getLinks(), (link) => {
+			let point = link.getPointForPort(this);
+			point.setPosition(point.getX() + x - old.x, point.getY() + y - old.y);
+		});
+	}
+
 	doClone(lookupTable = {}, clone: PortModel) {
 		clone.links = {};
 		clone.parent = this.getParent().clone(lookupTable);


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
At `NodeModel` and `PortModel` method `setPosition` currently doesn't work properly if we pass only Point as a first argument.

## Why?
Because `NodeModel.setPosition` for instance sets position to it's ports with this code:

https://github.com/projectstorm/react-diagrams/blob/dd68d1fe671925ba81d8e9e80ae6b3467e2d5c30/packages/react-diagrams-core/src/entities/node/NodeModel.ts#L42-L52

`x` can be PointModel and `y` we could never have, that's why ports never get correct position

## How?
We should use `this.position.x` and `this.position.y` for getting correct position for ports and points.

## Feel good image:

![image](https://user-images.githubusercontent.com/16336572/130625353-6bc9566a-224a-4de4-97da-565dfcbc902a.png)


