### PR TITLE
Update README.md with improved instructions for running the demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Take a look at the [demo project](https://github.com/projectstorm/react-diagrams
 
 ## Run the demos
 
-After running `yarn install` you must then run: `cd diagrams-demo-gallery && yarn run start`
+After running `yarn install` and `yarn build`, you must then run: `cd diagrams-demo-gallery && yarn run start`
 
 ## Building from source
 


### PR DESCRIPTION
Update the `Run the demos` section with additional instructions to get the demos running

# Checklist

> Do I need to do all of this for just a README edit?

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] ~~Had a beer/coffee because you are awesome~~ I had a sandwich

## What?
The instructions for running the demos was incomplete and the demos cannot be run if you follow the instructions exactly.

## Why?
There was a missing step: `yarn run build`.

## How?
 I updated the README with the missing instruction to build the project first before running the demo code.

## Feel good image:

![image](https://user-images.githubusercontent.com/6612736/136265212-30252c73-8ea2-451a-9265-1b423b42bd4d.png)

