### PR TITLE
Improve type of baseListener

### DIFF
--- a/packages/react-canvas-core/src/core/BaseObserver.ts
+++ b/packages/react-canvas-core/src/core/BaseObserver.ts
@@ -22,6 +22,7 @@ export type BaseListener = {
 	 * Generic event that fires after a specific event was fired (even if it was consumed)
 	 */
 	eventDidFire?: (event: BaseEvent & { function: string }) => void;
+} & {
 	/**
 	 * Type for other events that will fire
 	 */


### PR DESCRIPTION
# Checklist

- [x]  The code has been run through pretty yarn run pretty
- [ ]   The tests pass on CircleCI
- [x]   You have referenced the issue(s) or other PR(s) this fixes/relates-to #905 
- [x]   The PR Template has been filled out (see below)
- [x]   Had a beer because you are awesome

## What?
The type for the BaseListener should be updated.
It defines an index signature which enforces the return type for all properties to match the index signature return type.
Nevertheless, the parameters of eventDidFire() and eventWillFire do not match this index type.

There is a small fix to this issue provided in this pr 

## Why?
Improves the type system

## How?
Usage of union type
 
## Feel good image:
![FeelGood](https://user-images.githubusercontent.com/62144704/142638394-e8bec6d5-a993-4eb8-aa18-180c328b3b6b.jpeg)
