### PR TITLE
Correct bug of not deleted link

### DIFF
--- a/packages/react-diagrams-core/src/entities/link/LinkModel.ts
+++ b/packages/react-diagrams-core/src/entities/link/LinkModel.ts
@@ -163,9 +163,11 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 	remove() {
 		if (this.sourcePort) {
 			this.sourcePort.removeLink(this);
+			delete sourcePort;
 		}
 		if (this.targetPort) {
 			this.targetPort.removeLink(this);
+			delete targetPort;
 		}
 		super.remove();
 	}
@@ -277,6 +279,7 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 	}
 
 	removePoint(pointModel: PointModel) {
+		if (this.isLastPoint(pointModel)) this.remove();
 		this.points.splice(this.getPointIndex(pointModel), 1);
 	}
 

--- a/packages/react-diagrams-core/src/entities/link/LinkModel.ts
+++ b/packages/react-diagrams-core/src/entities/link/LinkModel.ts
@@ -163,11 +163,11 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 	remove() {
 		if (this.sourcePort) {
 			this.sourcePort.removeLink(this);
-			delete sourcePort;
+			delete super.sourcePort;
 		}
 		if (this.targetPort) {
 			this.targetPort.removeLink(this);
-			delete targetPort;
+			delete super.targetPort;
 		}
 		super.remove();
 	}

--- a/packages/react-diagrams-core/src/entities/link/LinkModel.ts
+++ b/packages/react-diagrams-core/src/entities/link/LinkModel.ts
@@ -163,11 +163,11 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 	remove() {
 		if (this.sourcePort) {
 			this.sourcePort.removeLink(this);
-			delete super.sourcePort;
+			delete this.sourcePort;
 		}
 		if (this.targetPort) {
 			this.targetPort.removeLink(this);
-			delete super.targetPort;
+			delete this.targetPort;
 		}
 		super.remove();
 	}


### PR DESCRIPTION
I correct the BUG of the Link doesn't delete when it's not connected to a target port  related on issue #895

# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Correct the bug linkModel.ts because link doesn't delete when you delete a link by it point.

## Why?
because the link doesn't delete

## How?
 delete the property to avoir NULL value

## Feel good image:

![image](https://user-images.githubusercontent.com/63649512/146956463-498b18a5-3404-48fe-b0be-8f6c33fcec27.png)


