### PR TITLE
Added call fireEvent when link was removed

### DIFF
--- a/packages/react-diagrams-core/src/entities/link/LinkModel.ts
+++ b/packages/react-diagrams-core/src/entities/link/LinkModel.ts
@@ -164,10 +164,12 @@ export class LinkModel<G extends LinkModelGenerics = LinkModelGenerics>
 		if (this.sourcePort) {
 			this.sourcePort.removeLink(this);
 			delete this.sourcePort;
+			this.fireEvent({ port: null }, 'sourcePortChanged');
 		}
 		if (this.targetPort) {
 			this.targetPort.removeLink(this);
 			delete this.targetPort;
+			this.fireEvent({ port: null }, 'targetPortChanged');
 		}
 		super.remove();
 	}


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
After merge this (https://github.com/projectstorm/react-diagrams/pull/914) PR into Master, I got problem with detect count of links for ports. Before it I used listener `linksUpdated` and each link had fields `sourcePort` and `targetPort`, but now are no there.


## How?
Links already have method `fireEvent` and I just used it :)

## Feel good image:

![image](https://user-images.githubusercontent.com/15737129/153392591-7c4bf01c-e4d7-4fc3-8295-0dbba5f85270.png)








