### PR TITLE
Register and enable the 'actions' addon panel

### DIFF
--- a/diagrams-demo-gallery/.storybook/manager.js
+++ b/diagrams-demo-gallery/.storybook/manager.js
@@ -1,4 +1,6 @@
 import { addons } from '@storybook/addons';
+import '@storybook/addon-actions/register';
+
 import diagramsTheme from './theme';
 
 addons.setConfig({


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?

The 'action-addon' panel is not visible, so registered it so the panel is now visible.

## Why?

It is not visible (both locally and the hosted version in production):
![image](https://user-images.githubusercontent.com/17981138/162639831-ae79642a-8aa6-45af-866c-64acb5d260de.png)

## How?

By registering the addon so it can show the panel.

Result:
![image](https://user-images.githubusercontent.com/17981138/162640041-03793d71-278d-4550-85a6-6c05cb1d2efa.png)

## Feel good image:

![LOL](https://user-images.githubusercontent.com/17981138/162639939-150ba700-95c1-4676-9f60-2d4170cd4abf.png)



