### PR TITLE
Remove hardcode for PointModel in DefaultLinkWidget.tsx

### DIFF
--- a/packages/react-diagrams-defaults/src/link/DefaultLinkWidget.tsx
+++ b/packages/react-diagrams-defaults/src/link/DefaultLinkWidget.tsx
@@ -58,11 +58,8 @@ export class DefaultLinkWidget extends React.Component<DefaultLinkProps, Default
 			!this.props.link.isLocked() &&
 			this.props.link.getPoints().length - 1 <= this.props.diagramEngine.getMaxNumberPointsPerLink()
 		) {
-			const point = new PointModel({
-				link: this.props.link,
-				position: this.props.diagramEngine.getRelativeMousePoint(event)
-			});
-			this.props.link.addPoint(point, index);
+			const position = this.props.diagramEngine.getRelativeMousePoint(event);
+			const point = this.props.link.point(position.x, position.y, index);
 			event.persist();
 			event.stopPropagation();
 			this.forceUpdate(() => {


### PR DESCRIPTION
# Checklist

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Remove hardcode for PointModel in `DefaultLinkWidget.tsx` (☞ﾟヮﾟ)☞
https://github.com/projectstorm/react-diagrams/issues/938

## Why?
1. Hardcode is bad
2. In current version of `DefaultLinkWidget` users can't use custom Points

## How?
Simply using the already existing `LinkModel` method ༼ つ ◕_◕ ༽つ

## Feel good image:
![image](https://user-images.githubusercontent.com/15737129/166709130-c57d9f6f-b8c0-4c0e-b655-9857d24cab9f.png)



