### PR TITLE
Update peer deps in react-canvas-core for working with React 18

### DIFF
--- a/packages/react-canvas-core/package.json
+++ b/packages/react-canvas-core/package.json
@@ -33,7 +33,7 @@
 	},
 	"peerDependencies": {
 		"lodash": "4.*",
-		"react": "16.* || 17.*"
+		"react": "18.*"
 	},
 	"gitHead": "bb878657ba0c2f81764f32901fd96158a0f8352e"
 }


### PR DESCRIPTION
# Checklist
Closes #929 

- [x] The code has been run through pretty `yarn run pretty`
- [x] The tests pass on CircleCI
- [x] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] The PR Template has been filled out (see below)
- [x] Had a beer/coffee because you are awesome

## What?
Finalize React 18 support

## Why?
At react-canvas-core remain 16 || 17 react

## How?
 Update react-canvas-core

## Feel good image:

(Add your own one below :])

![image](https://user-images.githubusercontent.com/16336572/177742682-e1701a81-9cff-4827-8754-d1b46c10e129.png)


