### PR TITLE
BugFix constructor overload in DefaultPortModel

### DIFF
--- a/.changeset/lucky-mayflies-design.md
+++ b/.changeset/lucky-mayflies-design.md
@@ -1,0 +1,5 @@
+---
+'@projectstorm/react-diagrams-defaults': major
+---
+
+bug fix

--- a/packages/react-diagrams-defaults/src/port/DefaultPortModel.ts
+++ b/packages/react-diagrams-defaults/src/port/DefaultPortModel.ts
@@ -22,7 +22,7 @@ export class DefaultPortModel extends PortModel<DefaultPortModelGenerics> {
 	constructor(isIn: boolean, name?: string, label?: string);
 	constructor(options: DefaultPortModelOptions);
 	constructor(options: DefaultPortModelOptions | boolean, name?: string, label?: string) {
-		if (!!name) {
+		if (typeof options === "boolean") {
 			options = {
 				in: !!options,
 				name: name,


### PR DESCRIPTION
# Checklist

- [ x] The tests pass --> I didn't found one for default implementation and didn't get them to run (see below)
- [ x] I have referenced the issue(s) or other PR(s) this fixes/relates-to --> didn't found any
- [x ] I have run ```pnpm changeset``` and followed the instructions
- [ x] I have explained in this PR, what I did and why
- [x ] I replaced the image below
- [ x] Had a beer/coffee/tea because I did something cool today

## What, why and how?
What: I changed the behaviour of setting "default" options when using the overloaded constructor of the DefaultPortModel.
Why: When creating a DefaultPortModel like: `new DefaultPortModel(true)` the in option wasn't set and label was undefined
How: Wanted to change it, first made name mandatory (would be another option) but then adopted style like in DefaultNodeModel to typechecking options.

## Feel good image:


![I Like](https://i.pinimg.com/750x/e7/88/2c/e7882cf4439c09b6365d528370b4fac0.jpg)

PS: It's my first contribution sorry for any mistakes on the process. 
PSS: wanted to Test but got: "The command '..' is incorrect or cannot be located in: reat-diagrams-routing test ../../node_modules/.bin/jest       but the file is there. Maybe you can help thanks.