### PR TITLE
fix: default link widget with react strict mode

### DIFF
--- a/.changeset/moody-radios-tease.md
+++ b/.changeset/moody-radios-tease.md
@@ -1,0 +1,5 @@
+---
+'@projectstorm/react-diagrams-defaults': patch
+---
+
+fix default link widget with react strict mode


### PR DESCRIPTION
# Checklist

- [x] The tests pass
- [x] I have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] I have run ```pnpm changeset``` and followed the instructions
- [x] I have explained in this PR, what I did and why
- [x] I replaced the image below
- [x] Had a beer/coffee/tea because I did something cool today

## What, why and how?

Solves #598, #618, #653, and #967 (the closed ones are closed with the workaround of removing strict mode).

React Strict Mode is recommended on production, DefaultLinkWidget was changing the component's state on render, which is not recommended by React. I refactored the component to use hooks, so now can be used with strict mode.

## Feel good image:

![LOL](https://i.imgflip.com/7vcbxm.jpg)