### PR TITLE
Allow more derived State classes to be parameterized with a generic type

### DIFF
--- a/.changeset/curly-doors-remain.md
+++ b/.changeset/curly-doors-remain.md
@@ -1,0 +1,6 @@
+---
+'@projectstorm/react-canvas-core': patch
+'@projectstorm/react-diagrams-core': patch
+---
+
+Allow more derived State classes to provide a generic type

--- a/packages/react-canvas-core/src/states/DragCanvasState.ts
+++ b/packages/react-canvas-core/src/states/DragCanvasState.ts
@@ -1,3 +1,4 @@
+import { CanvasEngine } from '../CanvasEngine';
 import { AbstractDisplacementState, AbstractDisplacementStateEvent } from '../core-state/AbstractDisplacementState';
 import { State } from '../core-state/State';
 
@@ -8,7 +9,7 @@ export interface DragCanvasStateOptions {
 	allowDrag?: boolean;
 }
 
-export class DragCanvasState extends AbstractDisplacementState {
+export class DragCanvasState<E extends CanvasEngine = CanvasEngine> extends AbstractDisplacementState<E> {
 	// store this as we drag the canvas
 	initialCanvasX: number;
 	initialCanvasY: number;

--- a/packages/react-canvas-core/src/states/SelectingState.ts
+++ b/packages/react-canvas-core/src/states/SelectingState.ts
@@ -2,8 +2,9 @@ import { State } from '../core-state/State';
 import { Action, ActionEvent, InputType } from '../core-actions/Action';
 import { SelectionBoxState } from './SelectionBoxState';
 import { MouseEvent } from 'react';
+import { CanvasEngine } from '../CanvasEngine';
 
-export class SelectingState extends State {
+export class SelectingState<E extends CanvasEngine = CanvasEngine> extends State<E> {
 	constructor() {
 		super({
 			name: 'selecting'

--- a/packages/react-canvas-core/src/states/SelectionBoxState.ts
+++ b/packages/react-canvas-core/src/states/SelectionBoxState.ts
@@ -4,6 +4,7 @@ import { SelectionLayerModel } from '../entities/selection/SelectionLayerModel';
 import { Point, Rectangle } from '@projectstorm/geometry';
 import { BasePositionModel } from '../core-models/BasePositionModel';
 import { ModelGeometryInterface } from '../core/ModelGeometryInterface';
+import { CanvasEngine } from '../CanvasEngine';
 
 export interface SimpleClientRect {
 	left: number;
@@ -14,7 +15,7 @@ export interface SimpleClientRect {
 	bottom: number;
 }
 
-export class SelectionBoxState extends AbstractDisplacementState {
+export class SelectionBoxState<E extends CanvasEngine = CanvasEngine> extends AbstractDisplacementState<E> {
 	layer: SelectionLayerModel;
 
 	constructor() {

--- a/packages/react-diagrams-core/src/states/DragDiagramItemsState.ts
+++ b/packages/react-diagrams-core/src/states/DragDiagramItemsState.ts
@@ -6,7 +6,7 @@ import { PortModel } from '../entities/port/PortModel';
 import { MouseEvent } from 'react';
 import { LinkModel } from '../entities/link/LinkModel';
 
-export class DragDiagramItemsState extends MoveItemsState<DiagramEngine> {
+export class DragDiagramItemsState<E extends DiagramEngine = DiagramEngine> extends MoveItemsState<E> {
 	constructor() {
 		super();
 		this.registerAction(

--- a/packages/react-diagrams-core/src/states/DragNewLinkState.ts
+++ b/packages/react-diagrams-core/src/states/DragNewLinkState.ts
@@ -22,7 +22,7 @@ export interface DragNewLinkStateOptions {
 	allowLinksFromLockedPorts?: boolean;
 }
 
-export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
+export class DragNewLinkState<E extends DiagramEngine = DiagramEngine> extends AbstractDisplacementState<E> {
 	port: PortModel;
 	link: LinkModel;
 	config: DragNewLinkStateOptions;


### PR DESCRIPTION
# Checklist

- [x] The tests pass
- [ ] I have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] I have run ```pnpm changeset``` and followed the instructions
- [x] I have explained in this PR, what I did and why
- [x] I replaced the image below
- [x] Had a beer/coffee/tea because I did something cool today

## What, why and how?

Prevent the need to do type assertions on the `engine` member on a number of classes which derive from `State` by adding a generic parameter which is passed to the derived class. 

## Feel good image:


![noice](https://media0.giphy.com/media/yJFeycRK2DB4c/giphy.gif)