### PR TITLE
fix the demos

### DIFF
--- a/.changeset/spicy-falcons-do.md
+++ b/.changeset/spicy-falcons-do.md
@@ -1,0 +1,5 @@
+---
+'@projectstorm/react-diagrams-gallery': patch
+---
+
+Fixed the demos

--- a/diagrams-demo-gallery/demos/demo-dagre/index.tsx
+++ b/diagrams-demo-gallery/demos/demo-dagre/index.tsx
@@ -68,10 +68,7 @@ function autoRefreshLinks(engine: DiagramEngine) {
 }
 
 function reroute(engine: DiagramEngine) {
-		engine
-			.getLinkFactories()
-			.getFactory<PathFindingLinkFactory>(PathFindingLinkFactory.NAME)
-			.calculateRoutingMatrix();
+	engine.getLinkFactories().getFactory<PathFindingLinkFactory>(PathFindingLinkFactory.NAME).calculateRoutingMatrix();
 }
 
 function DemoWidget(props) {
@@ -83,11 +80,11 @@ function DemoWidget(props) {
 
 	const redistribute = () => {
 		autoDistribute(engine);
-	}
+	};
 
 	const refreshLinks = () => {
 		autoRefreshLinks(engine);
-	}
+	};
 
 	return (
 		<DemoWorkspaceWidget


### PR DESCRIPTION
The custom demos were a bit broken as the `AdvancedLinkWidget` used to extend the `DefaultLinkWidget`. Obviously this is not a great pattern and this should rather be handled with mixins, utilities or even class extends. Ive just don't a bit of a patch for now.