### PR TITLE
fix: type guard update ActionEventBus.ts

### DIFF
--- a/packages/react-canvas-core/src/core-actions/ActionEventBus.ts
+++ b/packages/react-canvas-core/src/core-actions/ActionEventBus.ts
@@ -58,7 +58,12 @@ export class ActionEventBus {
 			return this.getActionsForType(InputType.KEY_DOWN);
 		} else if (event.type === 'keyup') {
 			// delete the recorded key
-			delete this.keys[(event as KeyboardEvent).key.toLowerCase()];
+			const kbEvent = event as KeyboardEvent;
+			const rawKey = kbEvent.key;
+	  	if (typeof rawKey === 'string' && rawKey.length > 0) {
+	    	const key = rawKey.toLowerCase();
+	    	delete this.keys[key];
+  		}
 			return this.getActionsForType(InputType.KEY_UP);
 		} else if (event.type === 'mousemove') {
 			return this.getActionsForType(InputType.MOUSE_MOVE);


### PR DESCRIPTION
# Checklist

- [ ] The tests pass
- [ ] I have referenced the issue(s) or other PR(s) this fixes/relates-to
- [ ] I have run ```pnpm changeset``` and followed the instructions
- [x] I have explained in this PR, what I did and why
- [x] I replaced the image below
- [ ] Had a beer/coffee/tea because I did something cool today

## What, why and how?
![스크린샷 2025-05-08 오후 2 44 50](https://github.com/user-attachments/assets/5b5d7bec-91a8-4291-8285-63287f181db0)
Got stucked in typescript error to undefined property, so created a simple guard if it is string type or not. 
Thank you in advance if there's a suggestion for giving better way to guard type.

## Feel good image:


![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)